### PR TITLE
Add Frodo976 and Frodo1344, fix typo in Frodo640 parameters

### DIFF
--- a/estimator/schemes.py
+++ b/estimator/schemes.py
@@ -138,8 +138,32 @@ Frodo640 = LWEParameters(
     m=2
     * (8 + 8)
     * 640
-    * 64,  # https://frodokem.org/files/FrodoKEM-specification-20210604.pdf#page=36
+    + 64,  # https://frodokem.org/files/FrodoKEM-specification-20210604.pdf#page=36
     tag="Frodo640",
+)
+
+Frodo976 = LWEParameters(
+    n=976,
+    q=2 ** 16,
+    Xs=NoiseDistribution.DiscreteGaussian(2.3),
+    Xe=NoiseDistribution.DiscreteGaussian(2.3),
+    m=2
+    * (8 + 8)
+    * 976
+    + 64,  # https://frodokem.org/files/FrodoKEM-specification-20210604.pdf#page=36
+    tag="Frodo976",
+)
+
+Frodo1344 = LWEParameters(
+    n=1344,
+    q=2 ** 16,
+    Xs=NoiseDistribution.DiscreteGaussian(1.4),
+    Xe=NoiseDistribution.DiscreteGaussian(1.4),
+    m=2
+    * (8 + 8)
+    * 1344
+    + 64,  # https://frodokem.org/files/FrodoKEM-specification-20210604.pdf#page=36
+    tag="Frodo1344",
 )
 
 # HES v1.1


### PR DESCRIPTION
Note that running ` LWE.estimate(Frodo1344)` causes the following error:

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-14-e7d71125592b> in <module>
----> 1 LWE.estimate(Frodo1344)

~/Desktop/lattice-estimator/estimator/lwe.py in __call__(self, params, red_cost_model, red_shape_model, deny_list, add_list, jobs)
    168             for k, v in res.items():
    169                 if algorithm == k:
--> 170                     if v["rop"] == oo:
    171                         continue
    172                     if k == "hybrid" and res["bdd"]["rop"] < v["rop"]:

TypeError: 'NoneType' object is not subscriptable
```