### PR TITLE
feat(lwe): add decoding variants to top level fn

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,9 +29,11 @@ Quick Start
 
     >>> r = LWE.estimate(Kyber512)
     arora-gb             :: rop: ≈2^inf, dreg: 25, mem: ≈2^106.3, t: 3, m: ≈2^inf, tag: arora-gb, ↻: ≈2^inf, ζ: 480
-    bkw                  :: rop: ≈2^178.8, m: ≈2^166.8, mem: ≈2^167.8, b: 14, t1: 0, t2: 16, ℓ: 13, #cod: 448, #top: 0, ...
+    bkw                  :: rop: ≈2^178.8, m: ≈2^166.8, mem: ≈2^167.8, b: 14, t1: 0, t2: 16, ℓ: 13, #cod: 448, #top: 0, #test: 64, tag: coded-bkw
     usvp                 :: rop: ≈2^150.4, red: ≈2^150.4, δ: 1.003941, β: 406, d: 998, tag: usvp
     bdd                  :: rop: ≈2^146.9, red: ≈2^146.3, svp: ≈2^145.4, β: 391, η: 421, d: 1013, tag: bdd
+    bdd_hybrid           :: rop: ≈2^146.9, red: ≈2^146.3, svp: ≈2^145.4, β: 391, η: 421, ζ: 0, |S|: 1, d: 1016, prob: 1, ↻: 1, tag: hybrid
+    bdd_mitm_hybrid      :: rop: ≈2^297.5, red: ≈2^297.5, svp: ≈2^167.3, β: 405, η: 2, ζ: 0, |S|: 1, d: 1025, prob: ≈2^-145.1, ↻: ≈2^147.3, tag: hybrid
     dual                 :: rop: ≈2^157.4, mem: ≈2^81.0, m: 512, β: 431, d: 1024, ↻: 1, tag: dual
     dual_hybrid          :: rop: ≈2^151.7, mem: ≈2^147.5, m: 512, β: 410, d: 999, ↻: 1, ζ: 25, tag: dual_hybrid
 

--- a/estimator/lwe.py
+++ b/estimator/lwe.py
@@ -110,13 +110,14 @@ class Estimate:
 
             >>> from estimator import *
             >>> _ = lwe.estimate(Kyber512)
-            arora-gb             :: rop: ≈2^inf, dreg: 25, mem: ≈2^106.3, t: 3, m: ≈2^inf, tag: arora-gb, ...
-            bkw                  :: rop: ≈2^178.8, m: ≈2^166.8, mem: ≈2^167.8, b: 14, t1: 0, t2: 16, ℓ: 13, ...
+            arora-gb             :: rop: ≈2^inf, dreg: 25, mem: ≈2^106.3, t: 3, m: ≈2^inf, tag: arora-gb, ↻: ≈2^inf, ζ: 480
+            bkw                  :: rop: ≈2^178.8, m: ≈2^166.8, mem: ≈2^167.8, b: 14, t1: 0, t2: 16, ℓ: 13, #cod: 448, #top: 0, #test: 64, tag: coded-bkw
             usvp                 :: rop: ≈2^150.4, red: ≈2^150.4, δ: 1.003941, β: 406, d: 998, tag: usvp
             bdd                  :: rop: ≈2^146.9, red: ≈2^146.3, svp: ≈2^145.4, β: 391, η: 421, d: 1013, tag: bdd
+            bdd_hybrid           :: rop: ≈2^146.9, red: ≈2^146.3, svp: ≈2^145.4, β: 391, η: 421, ζ: 0, |S|: 1, d: 1016, prob: 1, ↻: 1, tag: hybrid
+            bdd_mitm_hybrid      :: rop: ≈2^297.5, red: ≈2^297.5, svp: ≈2^167.3, β: 405, η: 2, ζ: 0, |S|: 1, d: 1025, prob: ≈2^-145.1, ↻: ≈2^147.3, tag: hybrid
             dual                 :: rop: ≈2^157.4, mem: ≈2^81.0, m: 512, β: 431, d: 1024, ↻: 1, tag: dual
             dual_hybrid          :: rop: ≈2^151.7, mem: ≈2^147.5, m: 512, β: 410, d: 999, ↻: 1, ζ: 25, tag: dual_hybrid
-
 
         """
         from sage.all import oo
@@ -141,8 +142,14 @@ class Estimate:
         algorithms["bdd"] = partial(
             primal_bdd, red_cost_model=red_cost_model, red_shape_model=red_shape_model
         )
-        algorithms["hybrid"] = partial(
-            primal_hybrid, red_cost_model=red_cost_model, red_shape_model=red_shape_model
+        algorithms["bdd_hybrid"] = partial(
+            primal_hybrid, mitm=False, babai=False, red_cost_model=red_cost_model,
+            red_shape_model=red_shape_model
+        )
+        # we ignore the case of mitm=True babai=False for now, due to it being overly-optimistic
+        algorithms["bdd_mitm_hybrid"] = partial(
+            primal_hybrid, mitm=True, babai=True, red_cost_model=red_cost_model,
+            red_shape_model=red_shape_model
         )
         algorithms["dual"] = partial(dual, red_cost_model=red_cost_model)
         algorithms["dual_hybrid"] = partial(

--- a/estimator/lwe.py
+++ b/estimator/lwe.py
@@ -110,12 +110,12 @@ class Estimate:
 
             >>> from estimator import *
             >>> _ = lwe.estimate(Kyber512)
-            arora-gb             :: rop: ≈2^inf, dreg: 25, mem: ≈2^106.3, t: 3, m: ≈2^inf, tag: arora-gb, ↻: ≈2^inf, ζ: 480
-            bkw                  :: rop: ≈2^178.8, m: ≈2^166.8, mem: ≈2^167.8, b: 14, t1: 0, t2: 16, ℓ: 13, #cod: 448, #top: 0, #test: 64, tag: coded-bkw
+            arora-gb             :: rop: ≈2^inf, dreg: 25, mem: ≈2^106.3, t: 3, m: ≈2^inf, tag: arora-gb, ↻: ≈2^inf, ...
+            bkw                  :: rop: ≈2^178.8, m: ≈2^166.8, mem: ≈2^167.8, b: 14, t1: 0, t2: 16, ℓ: 13, ...
             usvp                 :: rop: ≈2^150.4, red: ≈2^150.4, δ: 1.003941, β: 406, d: 998, tag: usvp
             bdd                  :: rop: ≈2^146.9, red: ≈2^146.3, svp: ≈2^145.4, β: 391, η: 421, d: 1013, tag: bdd
-            bdd_hybrid           :: rop: ≈2^146.9, red: ≈2^146.3, svp: ≈2^145.4, β: 391, η: 421, ζ: 0, |S|: 1, d: 1016, prob: 1, ↻: 1, tag: hybrid
-            bdd_mitm_hybrid      :: rop: ≈2^297.5, red: ≈2^297.5, svp: ≈2^167.3, β: 405, η: 2, ζ: 0, |S|: 1, d: 1025, prob: ≈2^-145.1, ↻: ≈2^147.3, tag: hybrid
+            bdd_hybrid           :: rop: ≈2^146.9, red: ≈2^146.3, svp: ≈2^145.4, β: 391, η: 421, ζ: 0, |S|: 1, ...
+            bdd_mitm_hybrid      :: rop: ≈2^297.5, red: ≈2^297.5, svp: ≈2^167.3, β: 405, η: 2, ζ: 0, |S|: 1, ...
             dual                 :: rop: ≈2^157.4, mem: ≈2^81.0, m: 512, β: 431, d: 1024, ↻: 1, tag: dual
             dual_hybrid          :: rop: ≈2^151.7, mem: ≈2^147.5, m: 512, β: 410, d: 999, ↻: 1, ζ: 25, tag: dual_hybrid
 


### PR DESCRIPTION
Update the top level function so that it outputs four decoding variants:

- `bdd`, as before
- `primal_hybrid` which calls `primal_hybrid` with `mitm = False` and `babai = False`
- `primal_mitm_hybrid` which calls `primal_hybrid` with `mitm = True` and `babai = True`
- `gv_mitm_hybrid` which calls `primal_hybrid` with `mitm = True` and `babai = False`

 We can ignore the fourth variant with `mitm = False` and `babai = True`, since this case should be covered by `primal_hybrid`.

Thoughts on the namings? We could instead do something like `gv_mitm_hybrid` -> `bdd_mitm_hybrid`.

Keeping as a draft PR for now, to check the tests etc.