### PR TITLE
bugfix(primal_hybrid): reduce via dual lattice for BKZ simulator

### DIFF
--- a/estimator/lwe_primal.py
+++ b/estimator/lwe_primal.py
@@ -299,7 +299,12 @@ class PrimalHybrid:
 
         # 1. Simulate BKZ-β
         # TODO: pick τ
-        r = simulator(d, params.n - zeta, params.q, beta, xi=xi)
+
+        try:
+            r = simulator(d, params.n - zeta, params.q, beta, xi=xi, dual=True)
+        except TypeError:
+            r = simulator(d, params.n - zeta, params.q, beta, xi=xi)
+
         bkz_cost = costf(red_cost_model, beta, d)
 
         # 2. Required SVP dimension η

--- a/estimator/simulator.py
+++ b/estimator/simulator.py
@@ -20,7 +20,7 @@ The last row is optional.
 from sage.all import RR, log
 
 
-def CN11(d, n, q, beta, xi=1, tau=1):
+def CN11(d, n, q, beta, xi=1, tau=1, dual=False):
     from fpylll import BKZ
     from fpylll.tools.bkz_simulator import simulate
 
@@ -29,7 +29,20 @@ def CN11(d, n, q, beta, xi=1, tau=1):
     else:
         r = [q ** 2] * (d - n) + [xi ** 2] * n
 
-    return simulate(r, BKZ.EasyParam(beta))[0]
+    if dual is False:
+        return simulate(r, BKZ.EasyParam(beta))[0]
+
+    else:
+        # 1. reverse and reflect the basis (go to dual)
+        r = [1/r_ for r_ in r[::-1]]
+
+        # 2. simulate reduction on the dual basis
+        r = simulate(r, BKZ.EasyParam(beta))[0]
+
+        # 3. reflect and reverse the basis (go back to primal)
+        r = [1/r_ for r_ in r[::-1]]
+
+        return r
 
 
 def GSA(d, n, q, beta, xi=1, tau=1):


### PR DESCRIPTION
As in issue #20, we reduce via the dual lattice for the primal_hybrid attack. Changes include:

1. in `simulator.py` we add a `dual` flag to the `CN11` model which allows to go via the dual basis when performing simulation.
2.  in `lwe_primal.py` we add an `if/else` statement to allow using 1. 

Happy to discuss any details/API changes we want to make here.