### PR TITLE
Add Dockerfiles

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,9 @@
-# A Dockerfile that can be used in isolation
 # syntax=docker/dockerfile:1
+
+# A Dockerfile that can be used without cloning the project manually. It uses
+# malb/lattice-estimator at HEAD. This is appropriate for users who want to use
+# malb/lattice-estimator but do not want to set up a local development
+# environment.
 FROM sagemath/sagemath:latest
 
 user root

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,13 @@
+# A Dockerfile that can be used in isolation
+# syntax=docker/dockerfile:1
+FROM sagemath/sagemath:latest
+
+user root
+RUN apt update && apt upgrade -y
+RUN apt install -y git
+
+RUN git clone https://github.com/malb/lattice-estimator.git /lattice-estimator
+WORKDIR /lattice-estimator
+
+RUN sage -pip install -r /lattice-estimator/requirements.txt
+CMD ["sage"]

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,0 +1,9 @@
+# A Dockerfile that can be used in isolation
+# syntax=docker/dockerfile:1
+FROM sagemath/sagemath:9.5
+
+COPY --chmod=777 . /lattice-estimator
+WORKDIR "/lattice-estimator"
+
+RUN sage -pip install -r requirements.txt
+CMD ["sage"]

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,5 +1,8 @@
-# A Dockerfile that can be used in isolation
 # syntax=docker/dockerfile:1
+
+# A Dockerfile that uses the local clone of lattice-estimator, incorporating
+# local changes that have not yet been merged into malb/lattice-estimator at
+# HEAD.
 FROM sagemath/sagemath:9.5
 
 COPY --chmod=777 . /lattice-estimator

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,19 @@
+# Running lattice estimator in a container
+
+Requires `docker` or `podman` to run the containers.
+
+From the base of the repository, run the following to build an image and run the
+tests within the container.
+
+```bash
+docker build -t lattice-estimator -f docker/Dockerfile.dev .
+docker run -dit --name lattice-estimator-tests lattice-estimator
+docker exec lattice-estimator-tests sage -sh -c pytest
+```
+
+Note that due to [this open
+ticket](https://trac.sagemath.org/ticket/34242#comment:20) on Sage, the
+published sage container is using an OEL'ed version of Ubunutu, and so we have
+to wait for the sagemath image to be updated in order to use `Dockerfile`
+standlone (`git clone`ing from inside the container).
+


### PR DESCRIPTION
This will help ensure I can reliably run the project's tests.

However, I did notice that the tests are very slow (with or without docker). What is the expected runtime of the tests? In particular, I see the following when running the `README.rst` tests

```bash
time docker exec lattice-estimator-tests sage -sh -c pytest -k README
<...>
0.33s user 0.40s system 0% cpu 4:50.98 total
```

(the whole test suite takes 21 minutes on my setup)

I suspect it could be sage startup time being incurred on each test case?