### PR TITLE
(bugfix): fix mpfr error in hybrid-dual

### DIFF
--- a/estimator/cost.py
+++ b/estimator/cost.py
@@ -265,6 +265,8 @@ class Cost:
         """
         Perform basic checks.
         """
+        if self.get("rop", 0) > 2**10000:
+            setattr(self, "rop", oo)
         if self.get("beta", 0) > self.get("d", 0):
             raise RuntimeError(f"β = {self['beta']} > d = {self['d']}")
         if self.get("eta", 0) > self.get("d", 0):

--- a/estimator/lwe_guess.py
+++ b/estimator/lwe_guess.py
@@ -217,7 +217,7 @@ class ExhaustiveSearch:
         cost = 2 * size * m
 
         ret = Cost(rop=cost, mem=cost / 2, m=m)
-        return ret
+        return ret.sanity_check()
 
     __name__ = "exhaustive_search"
 
@@ -428,7 +428,7 @@ class Distinguisher:
             raise InsufficientSamplesError(
                 "Not enough samples to distinguish with target advantage."
             )
-        return Cost(rop=m, mem=m, m=m)
+        return Cost(rop=m, mem=m, m=m).sanity_check()
 
     __name__ = "distinguish"
 


### PR DESCRIPTION
This PR fixes issue #38. 

The problem was related to the `exhaustive_search` function creating an overflow in mpfr. In particular, when:

`cost > 2**31 - 1`

we see an mpfr error which crashes sage. To fix this quickly, we can add a condition on `cost` in the `exhaustive search` function which sends anything over `2**31 - 1` to `oo`. This is really slow, so we use `2**10000` instead. We might want to revisit this later, so I've left a todo in the codebase.