### PR TITLE
Add schemes back to __init__.py.

### DIFF
--- a/estimator/__init__.py
+++ b/estimator/__init__.py
@@ -4,3 +4,4 @@ from .io import Logging  # noqa
 from .reduction import RC  # noqa
 from . import simulator as Simulator  # noqa
 from . import lwe as LWE  # noqa
+from . import schemes as schemes # noqa


### PR DESCRIPTION
Bizarrely, the tests pass but (at present) this code fails:

```
sage: from estimator import *
sage: schemes.Frodo640
... 
NameError: name 'schemes' is not defined.
```

This PR fixes this by adding an import for schemes to __init__.py. No idea why this wasn't caught by the CI. 