### PR TITLE
refactor to simplify tasks in util.py

### DIFF
--- a/estimator/lwe.py
+++ b/estimator/lwe.py
@@ -19,8 +19,8 @@ from .reduction import RC
 
 
 class Estimate:
-    @classmethod
-    def rough(cls, params, jobs=1, catch_exceptions=True):
+
+    def rough(self, params, jobs=1, catch_exceptions=True):
         """
         This function makes the following somewhat routine assumptions:
 
@@ -82,18 +82,19 @@ class Estimate:
         }
 
         for algorithm in algorithms:
-            for k, v in res.items():
-                if algorithm == k:
-                    if v["rop"] == oo:
-                        continue
-                    print(f"{algorithm:20s} :: {v!r}")
+            if algorithm not in res:
+                continue
+            result = res[algorithm]
+            if result["rop"] != oo:
+                print(f"{algorithm:20s} :: {result!r}")
+
         return res
 
     def __call__(
         self,
         params,
-        red_cost_model=None,
-        red_shape_model=None,
+        red_cost_model=red_cost_model_default,
+        red_shape_model=red_shape_model_default,
         deny_list=tuple(),
         add_list=tuple(),
         jobs=1,
@@ -124,11 +125,6 @@ class Estimate:
 
         """
         params = params.normalize()
-
-        if red_cost_model is None:
-            red_cost_model = red_cost_model_default
-        if red_shape_model is None:
-            red_shape_model = red_shape_model_default
 
         algorithms = {}
 
@@ -172,21 +168,24 @@ class Estimate:
         )
         res_raw = res_raw[params]
         res = {
-            algorithm: v for algorithm, attack in algorithms.items()
+            algorithm: v
+            for algorithm, attack in algorithms.items()
             for k, v in res_raw.items()
             if f_name(attack) == k
         }
 
         for algorithm in algorithms:
-            for k, v in res.items():
-                if algorithm == k:
-                    if v["rop"] == oo:
-                        continue
-                    if k == "hybrid" and res["bdd"]["rop"] < v["rop"]:
-                        continue
-                    if k == "dual_mitm_hybrid" and res["dual_hybrid"]["rop"] < v["rop"]:
-                        continue
-                    print(f"{algorithm:20s} :: {v!r}")
+            if algorithm not in res:
+                continue
+            result = res[algorithm]
+            if result["rop"] == oo:
+                continue
+            if algorithm == "hybrid" and res["bdd"]["rop"] < result["rop"]:
+                continue
+            if algorithm == "dual_mitm_hybrid" and res["dual_hybrid"]["rop"] < result["rop"]:
+                continue
+            print(f"{algorithm:20s} :: {result!r}")
+
         return res
 
 

--- a/estimator/lwe.py
+++ b/estimator/lwe.py
@@ -4,13 +4,18 @@ High-level LWE interface
 """
 
 from functools import partial
+from sage.all import oo
+
 from .lwe_primal import primal_usvp, primal_bdd, primal_hybrid
 from .lwe_bkw import coded_bkw
-from .lwe_guess import exhaustive_search, mitm, distinguish  # noqa
+from .lwe_guess import exhaustive_search, mitm, distinguish, guess_composition # noqa
 from .lwe_dual import dual, dual_hybrid
-from .lwe_guess import guess_composition
 from .gb import arora_gb  # noqa
 from .lwe_parameters import LWEParameters as Parameters  # noqa
+from .conf import (red_cost_model as red_cost_model_default,
+                   red_shape_model as red_shape_model_default)
+from .util import batch_estimate, f_name
+from .reduction import RC
 
 
 class Estimate:
@@ -42,12 +47,6 @@ class Estimate:
 
 
         """
-        # NOTE: Don't import these at the top-level to avoid circular imports
-        from .reduction import RC
-        from .util import batch_estimate, f_name
-
-        from sage.all import oo
-
         params = params.normalize()
 
         algorithms = {}
@@ -124,12 +123,6 @@ class Estimate:
             dual_hybrid          :: rop: ≈2^145.6, mem: ≈2^140.5, m: 512, β: 408, d: 1004, ↻: 1, ζ: 20, tag: dual_hybrid
 
         """
-        from sage.all import oo
-        from functools import partial
-        from .conf import red_cost_model as red_cost_model_default
-        from .conf import red_shape_model as red_shape_model_default
-        from .util import batch_estimate, f_name
-
         params = params.normalize()
 
         if red_cost_model is None:

--- a/estimator/util.py
+++ b/estimator/util.py
@@ -404,7 +404,7 @@ def batch_estimate(params, algorithm, jobs=1, log_level=0, catch_exceptions=True
     if jobs == 1:
         results = [_batch_estimatef(*task) for task in tasks]
     else:
-        with Pool(min(jobs, cpu_count())) as pool:
+        with Pool(jobs) as pool:
             results = pool.starmap(_batch_estimatef, tasks)
 
     return TaskResults(dict(zip(tasks, results)))

--- a/estimator/util.py
+++ b/estimator/util.py
@@ -1,4 +1,4 @@
-from multiprocessing import Pool
+from multiprocessing import Pool, cpu_count
 from functools import partial
 from dataclasses import dataclass
 import itertools as it
@@ -404,7 +404,7 @@ def batch_estimate(params, algorithm, jobs=1, log_level=0, catch_exceptions=True
     if jobs == 1:
         results = [_batch_estimatef(*task) for task in tasks]
     else:
-        with Pool(jobs) as pool:
+        with Pool(min(jobs, cpu_count())) as pool:
             results = pool.starmap(_batch_estimatef, tasks)
 
     return TaskResults(dict(zip(tasks, results)))

--- a/estimator/util.py
+++ b/estimator/util.py
@@ -1,4 +1,4 @@
-from multiprocessing import Pool, cpu_count
+from multiprocessing import Pool
 from functools import partial
 from dataclasses import dataclass
 import itertools as it

--- a/estimator/util.py
+++ b/estimator/util.py
@@ -9,6 +9,7 @@ from sage.all import ceil, floor, oo
 from .io import Logging
 from .lwe_parameters import LWEParameters
 
+
 class Bounds(NamedTuple):
     low: int
     high: int
@@ -368,7 +369,7 @@ class TaskResults:
         return {
             task.f_name: result
             for task, result in self._map.items()
-            if task.x == params and result != None
+            if task.x == params and result is not None
         }
 
 


### PR DESCRIPTION
The code in `batch_estimate` is noisy due to the datatype conversions. 
This PR:
- simplifies the code around tasks and results
- removes some unnecessary for loops
- adds a named tuple for limits/bounds to make access to those types more intuitive
- define the `Pool` in a context manager to be properly cleaned up