### PR TITLE
Fix slow Sage imports

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,5 +38,5 @@ jobs:
           # sage wants it
           sudo mkdir -p /usr/share/sagemath/build/pkgs
           # run tests
-          PYTHONIOENCODING=UTF-8 PYTHONPATH=`pwd` python -m pytest
+          PYTHONIOENCODING=UTF-8 PYTHONPATH=`pwd` python3 -m pytest
           

--- a/estimator/cost.py
+++ b/estimator/cost.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from collections import UserDict
 
+from sage.rings.all import QQ  # noqa: F401
 from sage.functions.log import log
 from sage.misc.functional import round
 from sage.rings.infinity import infinity as oo

--- a/estimator/cost.py
+++ b/estimator/cost.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from collections import UserDict
 
-from sage.all import log, oo, round
+from sage.functions.log import log
+from sage.misc.functional import round
+from sage.rings.infinity import infinity as oo
 
 
 # UserDict inherits from typing.MutableMapping

--- a/estimator/gb.py
+++ b/estimator/gb.py
@@ -5,21 +5,18 @@ Estimate cost of solving LWE using Gröbner bases.
 See :ref:`Arora-GB` for an overview.
 
 """
-from sage.all import (
-    binomial,
-    ceil,
-    exp,
-    floor,
-    log,
-    oo,
-    pi,
-    PowerSeriesRing,
-    prod,
-    QQ,
-    RR,
-    RealField,
-    sqrt,
-)
+from math import sqrt
+
+from sage.rings.all import QQ
+from sage.arith.misc import binomial
+from sage.functions.log import exp, log
+from sage.functions.other import ceil, floor
+from sage.misc.misc_c import prod
+from sage.rings.infinity import infinity as oo
+from sage.rings.power_series_ring import PowerSeriesRing
+from sage.rings.real_mpfr import RR, RealField
+from sage.symbolic.constants import pi
+
 from .cost import Cost
 from .lwe_parameters import LWEParameters
 from .io import Logging
@@ -72,7 +69,7 @@ class AroraGB:
         """
         RR = RealField(256)
         C = RR(C)
-        return RR(1 - (RR(2) / (C * RR(sqrt(2 * pi))) * exp(-(C**2) / RR(2))))
+        return RR(1 - (RR(2) / (C * sqrt(RR(2 * pi))) * exp(-(C**2) / RR(2))))
 
     @classmethod
     def cost_bounded(cls, params, success_probability=0.99, omega=2, log_level=1, **kwds):

--- a/estimator/gb.py
+++ b/estimator/gb.py
@@ -7,7 +7,7 @@ See :ref:`Arora-GB` for an overview.
 """
 from math import sqrt
 
-from sage.rings.all import QQ
+from sage.rings.all import QQ  # noqa: F401
 from sage.arith.misc import binomial
 from sage.functions.log import exp, log
 from sage.functions.other import ceil, floor

--- a/estimator/lwe.py
+++ b/estimator/lwe.py
@@ -4,7 +4,7 @@ High-level LWE interface
 """
 
 from functools import partial
-from sage.all import oo
+from sage.rings.infinity import infinity as oo
 
 from .lwe_primal import primal_usvp, primal_bdd, primal_hybrid
 from .lwe_bkw import coded_bkw

--- a/estimator/lwe.py
+++ b/estimator/lwe.py
@@ -3,6 +3,7 @@
 High-level LWE interface
 """
 
+from sage.rings.all import QQ  # noqa: F401
 from functools import partial
 from sage.rings.infinity import infinity as oo
 

--- a/estimator/lwe_bkw.py
+++ b/estimator/lwe_bkw.py
@@ -2,7 +2,17 @@
 """
 See :ref:`Coded-BKW for LWE` for what is available.
 """
-from sage.all import ZZ, ceil, log, floor, sqrt, var, find_root, erf, oo, cached_function
+from sage.rings.all import QQ
+from sage.calculus.var import var
+from sage.functions.all import log
+from sage.functions.error import erf
+from sage.functions.other import floor, ceil
+from sage.misc.cachefunc import cached_function
+from sage.misc.functional import sqrt
+from sage.numerical.optimize import find_root
+from sage.rings.infinity import infinity as oo
+from sage.rings.integer_ring import ZZ
+
 from .lwe_parameters import LWEParameters
 from .util import local_minimum
 from .cost import Cost

--- a/estimator/lwe_bkw.py
+++ b/estimator/lwe_bkw.py
@@ -2,7 +2,7 @@
 """
 See :ref:`Coded-BKW for LWE` for what is available.
 """
-from sage.rings.all import QQ
+from sage.rings.all import QQ  # noqa: F401
 from sage.calculus.var import var
 from sage.functions.all import log
 from sage.functions.error import erf

--- a/estimator/lwe_dual.py
+++ b/estimator/lwe_dual.py
@@ -9,7 +9,7 @@ See :ref:`LWE Dual Attacks` for an introduction what is available.
 from functools import partial
 from dataclasses import replace
 
-from sage.rings.all import QQ
+from sage.rings.all import QQ  # noqa: F401
 from sage.functions.log import exp, log
 from sage.functions.other import ceil
 from sage.misc.cachefunc import cached_function

--- a/estimator/lwe_dual.py
+++ b/estimator/lwe_dual.py
@@ -10,8 +10,7 @@ from functools import partial
 from dataclasses import replace
 
 from sage.rings.all import QQ
-from sage.functions.log import exp
-from sage.functions.log import log
+from sage.functions.log import exp, log
 from sage.functions.other import ceil
 from sage.misc.cachefunc import cached_function
 from sage.misc.functional import sqrt

--- a/estimator/lwe_dual.py
+++ b/estimator/lwe_dual.py
@@ -9,7 +9,15 @@ See :ref:`LWE Dual Attacks` for an introduction what is available.
 from functools import partial
 from dataclasses import replace
 
-from sage.all import oo, ceil, sqrt, log, cached_function, RR, exp, pi
+from sage.rings.all import QQ
+from sage.functions.log import exp
+from sage.functions.log import log
+from sage.functions.other import ceil
+from sage.misc.cachefunc import cached_function
+from sage.misc.functional import sqrt
+from sage.rings.infinity import infinity as oo
+from sage.rings.real_mpfr import RR
+from sage.symbolic.constants import pi
 
 from .reduction import delta as deltaf
 from .util import local_minimum

--- a/estimator/lwe_guess.py
+++ b/estimator/lwe_guess.py
@@ -7,7 +7,15 @@ some form of additive composition, i.e. this strategy is rarely the most efficie
 
 """
 
-from sage.all import binomial, ceil, e, exp, floor, log, oo, pi, round, RR, sqrt, ZZ
+from sage.rings.all import QQ
+from sage.arith.misc import binomial
+from sage.functions.log import exp, log
+from sage.functions.other import ceil, floor
+from sage.misc.functional import sqrt, round
+from sage.rings.infinity import infinity as oo
+from sage.rings.integer_ring import ZZ
+from sage.rings.real_mpfr import RR
+from sage.symbolic.constants import e, pi
 
 from .conf import mitm_opt
 from .cost import Cost
@@ -183,7 +191,7 @@ class ExhaustiveSearch:
             return Cost(rop=oo, mem=oo, m=1)
 
         if quantum is True:
-            size = size.sqrt()
+            size = sqrt(size)
 
         # set m according to [ia.cr/2020/515]
         sigma = params.Xe.stddev / params.q

--- a/estimator/lwe_guess.py
+++ b/estimator/lwe_guess.py
@@ -7,7 +7,7 @@ some form of additive composition, i.e. this strategy is rarely the most efficie
 
 """
 
-from sage.rings.all import QQ
+from sage.rings.all import QQ  # noqa: F401
 from sage.arith.misc import binomial
 from sage.functions.log import exp, log
 from sage.functions.other import ceil, floor

--- a/estimator/lwe_parameters.py
+++ b/estimator/lwe_parameters.py
@@ -2,7 +2,12 @@
 from dataclasses import dataclass
 from copy import copy
 
-from sage.all import oo, binomial, log, sqrt, ceil
+from sage.rings.all import QQ
+from sage.arith.misc import binomial
+from sage.functions.log import log
+from sage.functions.other import ceil
+from sage.misc.functional import sqrt
+from sage.rings.infinity import infinity as oo
 
 from .nd import NoiseDistribution
 from .errors import InsufficientSamplesError

--- a/estimator/lwe_parameters.py
+++ b/estimator/lwe_parameters.py
@@ -2,7 +2,7 @@
 from dataclasses import dataclass
 from copy import copy
 
-from sage.rings.all import QQ
+from sage.rings.all import QQ  # noqa: F401
 from sage.arith.misc import binomial
 from sage.functions.log import log
 from sage.functions.other import ceil

--- a/estimator/lwe_primal.py
+++ b/estimator/lwe_primal.py
@@ -7,7 +7,7 @@ See :ref:`LWE Primal Attacks` for an introduction what is available.
 """
 from functools import partial
 
-from sage.rings.all import QQ
+from sage.rings.all import QQ  # noqa: F401
 from sage.arith.misc import binomial
 from sage.functions.log import log
 from sage.functions.other import ceil

--- a/estimator/lwe_primal.py
+++ b/estimator/lwe_primal.py
@@ -7,7 +7,16 @@ See :ref:`LWE Primal Attacks` for an introduction what is available.
 """
 from functools import partial
 
-from sage.all import oo, ceil, sqrt, log, RR, ZZ, binomial, cached_function
+from sage.rings.all import QQ
+from sage.arith.misc import binomial
+from sage.functions.log import log
+from sage.functions.other import ceil
+from sage.misc.cachefunc import cached_function
+from sage.misc.functional import sqrt
+from sage.rings.infinity import infinity as oo
+from sage.rings.integer_ring import ZZ
+from sage.rings.real_mpfr import RR
+
 from .reduction import delta as deltaf
 from .reduction import cost as costf
 from .util import local_minimum

--- a/estimator/nd.py
+++ b/estimator/nd.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 
-from sage.rings.all import QQ
+from sage.rings.all import QQ  # noqa: F401
 from sage.arith.misc import binomial
 from sage.functions.log import exp, log
 from sage.functions.other import ceil
@@ -11,6 +11,7 @@ from sage.rings.infinity import infinity as oo
 from sage.rings.real_mpfr import RealField, RR
 from sage.structure.element import parent
 from sage.symbolic.constants import pi
+
 
 def stddevf(sigma):
     """

--- a/estimator/nd.py
+++ b/estimator/nd.py
@@ -2,8 +2,15 @@
 
 from dataclasses import dataclass
 
-from sage.all import binomial, ceil, exp, log, oo, parent, pi, RealField, RR, sqrt
-
+from sage.rings.all import QQ
+from sage.arith.misc import binomial
+from sage.functions.log import exp, log
+from sage.functions.other import ceil
+from sage.misc.functional import sqrt
+from sage.rings.infinity import infinity as oo
+from sage.rings.real_mpfr import RealField, RR
+from sage.structure.element import parent
+from sage.symbolic.constants import pi
 
 def stddevf(sigma):
     """

--- a/estimator/prob.py
+++ b/estimator/prob.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from sage.rings.all import QQ
+from sage.rings.all import QQ  # noqa: F401
 from sage.arith.misc import binomial
 from sage.functions.all import exp, log
 from sage.functions.error import erf

--- a/estimator/prob.py
+++ b/estimator/prob.py
@@ -1,6 +1,18 @@
 # -*- coding: utf-8 -*-
-from sage.all import binomial, ZZ, log, ceil, RealField, oo, exp, pi
-from sage.all import RealDistribution, RR, sqrt, prod, erf
+
+from sage.rings.all import QQ
+from sage.arith.misc import binomial
+from sage.functions.all import exp, log
+from sage.functions.error import erf
+from sage.functions.other import ceil
+from sage.misc.functional import sqrt
+from sage.misc.misc_c import prod
+from sage.probability.probability_distribution import RealDistribution
+from sage.rings.infinity import infinity as oo
+from sage.rings.integer_ring import ZZ
+from sage.rings.real_mpfr import RealField, RR
+from sage.symbolic.constants import pi
+
 from .nd import sigmaf
 
 

--- a/estimator/reduction.py
+++ b/estimator/reduction.py
@@ -3,7 +3,16 @@
 Cost estimates for lattice redution.
 """
 
-from sage.all import ZZ, RR, pi, e, find_root, ceil, floor, log, oo, round, sqrt
+from sage.rings.all import QQ
+from sage.functions.log import log
+from sage.functions.other import ceil, floor
+from sage.misc.functional import sqrt, round
+from sage.numerical.optimize import find_root
+from sage.rings.infinity import infinity as oo
+from sage.rings.integer_ring import ZZ
+from sage.rings.real_mpfr import RR
+from sage.symbolic.constants import e, pi
+
 from scipy.optimize import newton
 
 from .cost import Cost

--- a/estimator/reduction.py
+++ b/estimator/reduction.py
@@ -3,7 +3,7 @@
 Cost estimates for lattice redution.
 """
 
-from sage.rings.all import QQ
+from sage.rings.all import QQ  # noqa: F401
 from sage.functions.log import log
 from sage.functions.other import ceil, floor
 from sage.misc.functional import sqrt, round

--- a/estimator/simulator.py
+++ b/estimator/simulator.py
@@ -17,8 +17,9 @@ where
 The last row is optional.
 """
 
-from sage.all import RR, log, line
-
+from sage.functions.log import log
+from sage.plot.line import line
+from sage.rings.real_mpfr import RR
 
 def qary_simulator(f, d, n, q, beta, xi=1, tau=1, dual=False):
     """

--- a/estimator/simulator.py
+++ b/estimator/simulator.py
@@ -21,6 +21,7 @@ from sage.functions.log import log
 from sage.plot.line import line
 from sage.rings.real_mpfr import RR
 
+
 def qary_simulator(f, d, n, q, beta, xi=1, tau=1, dual=False):
     """
     Reduced lattice shape calling ``f``.

--- a/estimator/util.py
+++ b/estimator/util.py
@@ -4,7 +4,9 @@ from functools import partial
 from dataclasses import dataclass
 from typing import Any, Callable, NamedTuple
 
-from sage.all import ceil, floor, log, oo
+from sage.functions.other import ceil, floor
+from sage.functions.log import log
+from sage.rings.infinity import infinity as oo
 
 from .io import Logging
 from .lwe_parameters import LWEParameters

--- a/estimator/util.py
+++ b/estimator/util.py
@@ -4,6 +4,7 @@ from functools import partial
 from dataclasses import dataclass
 from typing import Any, Callable, NamedTuple
 
+from sage.rings.all import QQ  # noqa: F401
 from sage.functions.other import ceil, floor
 from sage.functions.log import log
 from sage.rings.infinity import infinity as oo


### PR DESCRIPTION
By replacing all Sage imports with an individual imoprt, the loading time for `from estimator import *` reduces from 3.5s to 1.4s. Doctests seem to work (except for timeout stuffs) so I assume I didn't break anything 😄 