### PR TITLE
Speed up `coded_bkw` computation

### DIFF
--- a/estimator/lwe_bkw.py
+++ b/estimator/lwe_bkw.py
@@ -2,7 +2,7 @@
 """
 See :ref:`Coded-BKW for LWE` for what is available.
 """
-from sage.all import ZZ, ceil, log, floor, sqrt, var, find_root, erf, oo, cached_function
+from sage.all import ZZ, ceil, log, floor, sqrt, find_root, erf, oo, cached_function
 
 from .lwe_parameters import LWEParameters
 from .util import local_minimum

--- a/estimator/lwe_bkw.py
+++ b/estimator/lwe_bkw.py
@@ -3,6 +3,7 @@
 See :ref:`Coded-BKW for LWE` for what is available.
 """
 from sage.rings.all import QQ
+from sage.functions.all import log
 from sage.functions.error import erf
 from sage.functions.other import floor, ceil
 from sage.misc.cachefunc import cached_function

--- a/estimator/lwe_bkw.py
+++ b/estimator/lwe_bkw.py
@@ -3,8 +3,6 @@
 See :ref:`Coded-BKW for LWE` for what is available.
 """
 from sage.rings.all import QQ
-from sage.calculus.var import var
-from sage.functions.all import log
 from sage.functions.error import erf
 from sage.functions.other import floor, ceil
 from sage.misc.cachefunc import cached_function

--- a/estimator/lwe_bkw.py
+++ b/estimator/lwe_bkw.py
@@ -2,16 +2,7 @@
 """
 See :ref:`Coded-BKW for LWE` for what is available.
 """
-from sage.rings.all import QQ
-from sage.functions.all import log
-from sage.functions.error import erf
-from sage.functions.other import floor, ceil
-from sage.misc.cachefunc import cached_function
-from sage.misc.functional import sqrt
-from sage.numerical.optimize import find_root
-from sage.rings.infinity import infinity as oo
-from sage.rings.integer_ring import ZZ
-from sage.rings.real_mpfr import RR
+from sage.all import ZZ, ceil, log, floor, sqrt, var, find_root, erf, oo, cached_function
 
 from .lwe_parameters import LWEParameters
 from .util import local_minimum

--- a/estimator/lwe_bkw.py
+++ b/estimator/lwe_bkw.py
@@ -2,7 +2,18 @@
 """
 See :ref:`Coded-BKW for LWE` for what is available.
 """
-from sage.all import ZZ, ceil, log, floor, sqrt, var, find_root, erf, oo, cached_function
+from sage.rings.all import QQ
+from sage.calculus.var import var
+from sage.functions.all import log
+from sage.functions.error import erf
+from sage.functions.other import floor, ceil
+from sage.misc.cachefunc import cached_function
+from sage.misc.functional import sqrt
+from sage.numerical.optimize import find_root
+from sage.rings.infinity import infinity as oo
+from sage.rings.integer_ring import ZZ
+from sage.rings.real_mpfr import RR
+
 from .lwe_parameters import LWEParameters
 from .util import local_minimum
 from .cost import Cost
@@ -44,10 +55,13 @@ class CodedBKW:
             return 0
 
         # solve for ntest by aiming for ntop == 0
-        ntest = var("ntest")
-        sigma_set = sqrt(q ** (2 * (1 - ell / ntest)) / 12)
-        ncod = sum(CodedBKW.N(i, sigma_set, b, q) for i in range(1, t2 + 1))
-        ntop = n - ncod - ntest - t1 * b
+        def ntop(ntest):
+            # Patch so that `find_root` (which uses float) doesn't error
+            ntest = RR(ntest)
+            sigma_set = sqrt(q ** (2 * (1 - ell / ntest)) / 12)
+            ncod = sum(CodedBKW.N(i, sigma_set, b, q) for i in range(1, t2 + 1))
+            res = n - ncod - ntest - t1 * b
+            return res
 
         try:
             start = max(int(round(find_root(ntop, 2, n - t1 * b + 1, rtol=0.1))) - 1, 2)
@@ -55,7 +69,7 @@ class CodedBKW:
             start = 2
         ntest_min = 1
         for ntest in range(start, n - t1 * b + 1):
-            if abs(ntop(ntest=ntest).n()) >= abs(ntop(ntest=ntest_min).n()):
+            if abs(ntop(ntest).n()) >= abs(ntop(ntest_min).n()):
                 break
             ntest_min = ntest
         return int(ntest_min)


### PR DESCRIPTION
Avoids symbolic computation at all cost for faster computation, especially since on line 62 there's a `sum` which computes the sum of (I believe) hundreds of expressions. Benchmarks on my laptop:

Kyber512: 277.6s -> 12.25s
Kyber1024: Long time -> 17.40s
TFHE630: 539.4s -> 20.15s

Look at that, 20x speed up! I'll also benchmark other places of the code and see what other fixes I have.

Depends on #76 for the changed import list. Hopefully it helps (beginning to?) resolve #74 and #75.