### PR TITLE
Change memory usage of dual attack

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Quick Start
     bdd                  :: rop: ≈2^140.3, red: ≈2^139.7, svp: ≈2^138.8, β: 391, η: 421, d: 1013, tag: bdd
     bdd_hybrid           :: rop: ≈2^140.3, red: ≈2^139.7, svp: ≈2^138.8, β: 391, η: 421, ζ: 0, |S|: 1, d: 1016, prob: 1, ↻: 1, tag: hybrid
     bdd_mitm_hybrid      :: rop: ≈2^260.3, red: ≈2^259.4, svp: ≈2^259.3, β: 405, η: 2, ζ: 102, |S|: ≈2^247.2, d: 923, prob: ≈2^-113.8, ↻: ≈2^116.0, tag: hybrid
-    dual                 :: rop: ≈2^149.9, mem: ≈2^88.0, m: 512, β: 424, d: 1024, ↻: 1, tag: dual
+    dual                 :: rop: ≈2^149.9, mem: ≈2^97.1, m: 512, β: 424, d: 1024, ↻: 1, tag: dual
     dual_hybrid          :: rop: ≈2^145.6, mem: ≈2^140.5, m: 512, β: 408, d: 1004, ↻: 1, ζ: 20, tag: dual_hybrid
 
 - `Try it in your browser <https://mybinder.org/v2/gh/malb/lattice-estimator/jupyter-notebooks?labpath=..%2F..%2Ftree%2Fprompt.ipynb>`__.

--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,7 @@ At present, this estimator is maintained by Martin Albrecht. Contributors are:
 - Hamish Hunt
 - James Owen
 - Léo Ducas
+- Ludo Pulles
 - Markus Schmidt
 - Martin Albrecht
 - Michael Walter

--- a/estimator/gb.py
+++ b/estimator/gb.py
@@ -220,7 +220,7 @@ class AroraGB:
         ..  [EPRINT:ACFP14] Martin R. Albrecht, Carlos Cid, Jean-Charles Faugère & Ludovic Perret. (2014).
             Algebraic algorithms for LWE. https://eprint.iacr.org/2014/1018
 
-        ..  [ICALP:AroGe11] Sanjeev Aror & Rong Ge. (2011). New algorithms for learning in presence of
+        ..  [ICALP:AroGe11] Sanjeev Arora & Rong Ge. (2011). New algorithms for learning in presence of
             errors.  In L.  Aceto, M.  Henzinger, & J.  Sgall, ICALP 2011, Part I (pp.  403–415).:
             Springer, Heidelberg.
         """

--- a/estimator/lwe.py
+++ b/estimator/lwe.py
@@ -120,7 +120,7 @@ class Estimate:
             bdd                  :: rop: ≈2^140.3, red: ≈2^139.7, svp: ≈2^138.8, β: 391, η: 421, d: 1013, tag: bdd
             bdd_hybrid           :: rop: ≈2^140.3, red: ≈2^139.7, svp: ≈2^138.8, β: 391, η: 421, ζ: 0, |S|: 1, ...
             bdd_mitm_hybrid      :: rop: ≈2^260.3, red: ≈2^259.4, svp: ≈2^259.3, β: 405, η: 2, ζ: 102, |S|: ≈2^247.2,...
-            dual                 :: rop: ≈2^149.9, mem: ≈2^88.0, m: 512, β: 424, d: 1024, ↻: 1, tag: dual
+            dual                 :: rop: ≈2^149.9, mem: ≈2^97.1, m: 512, β: 424, d: 1024, ↻: 1, tag: dual
             dual_hybrid          :: rop: ≈2^145.6, mem: ≈2^140.5, m: 512, β: 408, d: 1004, ↻: 1, ζ: 20, tag: dual_hybrid
 
         """

--- a/estimator/lwe_dual.py
+++ b/estimator/lwe_dual.py
@@ -328,7 +328,7 @@ class DualHybrid:
         the cost function for the dual hybrid might only be convex in an approximate
         sense, the parameter ``opt_step`` allows to make the optimization procedure more
         robust against local irregularities (higher value) at the cost of a longer
-        running time. In a nutshell, if the cost of the dual hybrid seems suspiciosly
+        running time. In a nutshell, if the cost of the dual hybrid seems suspiciously
         high, try a larger ``opt_step`` (e.g. 4 or 8).
 
         :param solver: Algorithm for solving the reduced instance

--- a/estimator/lwe_dual.py
+++ b/estimator/lwe_dual.py
@@ -408,7 +408,8 @@ class DualHybrid:
             rop: ≈2^206.9, mem: ≈2^137.5, m: ≈2^11.8, β: 616, d: 7779, ↻: 1, tag: dual
 
             >>> LWE.dual_hybrid(schemes.Kyber512, red_cost_model=RC.GJ21, fft=True)
-            rop: ≈2^149.9, mem: ≈2^92.3, m: 511, β: 400, t: 76, d: 1002, ↻: 1, ζ: 21, tag: dual_hybrid
+            rop: ≈2^149.8, mem: ≈2^92.1, m: 510, t: 76, β: 399, d: 1000, ↻: 1, ζ: 22, tag: dual_hybrid
+
         """
 
         Cost.register_impermanent(

--- a/estimator/lwe_dual.py
+++ b/estimator/lwe_dual.py
@@ -118,7 +118,6 @@ class DualHybrid:
         t: int = 0,
         success_probability: float = 0.99,
         red_cost_model=red_cost_model_default,
-        use_lll=True,
         log_level=None,
     ):
         """
@@ -132,7 +131,6 @@ class DualHybrid:
         :param h1: Number of non-zero components of the secret of the new LWE instance
         :param success_probability: The success probability to target
         :param red_cost_model: How to cost lattice reduction
-        :param use_lll: Use LLL calls to produce more small vectors
 
         .. note :: This function assumes that the instance is normalized. It runs no optimization,
             it merely reports costs.
@@ -245,7 +243,6 @@ class DualHybrid:
         h1: int = 0,
         success_probability: float = 0.99,
         red_cost_model=red_cost_model_default,
-        use_lll=True,
         log_level=5,
         opt_step=8,
         fft=False,
@@ -259,7 +256,6 @@ class DualHybrid:
         :param h1: Number of non-zero components of the secret of the new LWE instance
         :param success_probability: The success probability to target
         :param red_cost_model: How to cost lattice reduction
-        :param use_lll: Use LLL calls to produce more small vectors
         :param opt_step: control robustness of optimizer
         :param fft: use the FFT distinguisher from [AC:GuoJoh21]_
 
@@ -275,7 +271,6 @@ class DualHybrid:
             h1=h1,
             success_probability=success_probability,
             red_cost_model=red_cost_model,
-            use_lll=use_lll,
             log_level=log_level,
         )
 
@@ -316,7 +311,6 @@ class DualHybrid:
         params: LWEParameters,
         success_probability: float = 0.99,
         red_cost_model=red_cost_model_default,
-        use_lll=True,
         opt_step=8,
         log_level=1,
         fft=False,
@@ -335,7 +329,6 @@ class DualHybrid:
         :param params: LWE parameters
         :param success_probability: The success probability to target
         :param red_cost_model: How to cost lattice reduction
-        :param use_lll: use LLL calls to produce more small vectors [EC:Albrecht17]_
         :param opt_step: control robustness of optimizer
         :param fft: use the FFT distinguisher from [AC:GuoJoh21]_. (ignored for sparse secrets)
 
@@ -430,7 +423,6 @@ class DualHybrid:
                 zeta: int = 0,
                 success_probability: float = 0.99,
                 red_cost_model=red_cost_model_default,
-                use_lll=True,
                 log_level=None,
                 fft=False,
             ):
@@ -450,7 +442,6 @@ class DualHybrid:
                             zeta=zeta,
                             success_probability=success_probability,
                             red_cost_model=red_cost_model,
-                            use_lll=use_lll,
                             log_level=log_level + 2,
                         )
                         it.update(cost)
@@ -465,7 +456,6 @@ class DualHybrid:
             params=params,
             success_probability=success_probability,
             red_cost_model=red_cost_model,
-            use_lll=use_lll,
             log_level=log_level + 1,
             fft=fft,
         )
@@ -488,7 +478,6 @@ def dual(
     params: LWEParameters,
     success_probability: float = 0.99,
     red_cost_model=red_cost_model_default,
-    use_lll=True,
 ):
     """
     Dual hybrid attack as in [PQCBook:MicReg09]_.
@@ -496,7 +485,6 @@ def dual(
     :param params: LWE parameters.
     :param success_probability: The success probability to target.
     :param red_cost_model: How to cost lattice reduction.
-    :param use_lll: use LLL calls to produce more small vectors [EC:Albrecht17]_.
 
     The returned cost dictionary has the following entries:
 
@@ -527,7 +515,6 @@ def dual(
         h1=0,
         success_probability=success_probability,
         red_cost_model=red_cost_model,
-        use_lll=use_lll,
         log_level=1,
     )
     del ret["zeta"]
@@ -541,7 +528,6 @@ def dual_hybrid(
     params: LWEParameters,
     success_probability: float = 0.99,
     red_cost_model=red_cost_model_default,
-    use_lll=True,
     mitm_optimization=False,
     opt_step=8,
     fft=False,
@@ -552,7 +538,6 @@ def dual_hybrid(
     :param params: LWE parameters.
     :param success_probability: The success probability to target.
     :param red_cost_model: How to cost lattice reduction.
-    :param use_lll: Use LLL calls to produce more small vectors [EC:Albrecht17]_.
     :param mitm_optimization: One of "analytical" or "numerical". If ``True`` a default from the
            ``conf`` module is picked, ``False`` disables MITM.
     :param opt_step: Control robustness of optimizer.
@@ -586,7 +571,6 @@ def dual_hybrid(
         params=params,
         success_probability=success_probability,
         red_cost_model=red_cost_model,
-        use_lll=use_lll,
         opt_step=opt_step,
         fft=fft,
     )

--- a/estimator/lwe_guess.py
+++ b/estimator/lwe_guess.py
@@ -195,15 +195,13 @@ class ExhaustiveSearch:
             raise InsufficientSamplesError(
                 f"Exhaustive search: Need {m_required} samples but only {params.m} available."
             )
-        else:
-            m = m_required
 
         # we can compute A*s for all candidate s in time 2*size*m using
         # (the generalization [ia.cr/2021/152] of) the recursive algorithm
         # from [ia.cr/2020/515]
-        cost = 2 * size * m
+        cost = 2 * size * m_required
 
-        ret = Cost(rop=cost, mem=cost / 2, m=m)
+        ret = Cost(rop=cost, mem=cost / 2, m=m_required)
         return ret.sanity_check()
 
     __name__ = "exhaustive_search"
@@ -253,15 +251,15 @@ class MITM:
             success_probability_ = 1.0
             logT = k * log(sd_rng, 2)
 
-        m_ = max(1, round(logT + log2(logT)))
-        if params.m < m_:
+        m_required = max(1, round(logT + log2(logT)))
+        if params.m < m_required:
             raise InsufficientSamplesError(
-                f"MITM: Need {m_} samples but only {params.m} available."
+                f"MITM: Need {m_required} samples but only {params.m} available."
             )
 
         # since m = logT + loglogT and rop = T*m, we have rop=2^m
-        ret = Cost(rop=RR(2**m_), mem=2**logT * m_, m=m_, k=ZZ(k))
-        repeat = prob_amplify(success_probability, sd_p**n * nd_p**m_ * success_probability_)
+        ret = Cost(rop=RR(2**m_required), mem=2**logT * m_required, m=m_required, k=ZZ(k))
+        repeat = prob_amplify(success_probability, sd_p**n * nd_p**m_required * success_probability_)
         return ret.repeat(times=repeat)
 
     def cost(

--- a/estimator/prob.py
+++ b/estimator/prob.py
@@ -77,7 +77,7 @@ def amplify(target_success_probability, success_probability, majority=False):
 
     :param target_success_probability: targeted success probability < 1
     :param success_probability: targeted success probability < 1
-    :param majority: if `True` amplify a deicsional problem, not a computational one
+    :param majority: if `True` amplify a decisional problem, not a computational one
        if `False` then we assume that we can check solutions, so one success suffices
 
     :returns: number of required trials to amplify

--- a/estimator/reduction.py
+++ b/estimator/reduction.py
@@ -846,7 +846,7 @@ class GJ21(Kyber):
         if sieve_dim is None:
             sieve_dim = beta_
             if beta < d:
-                # set beta_sieve such that complexity of 1 sieve in in dim sieve_dim is approx
+                # set beta_sieve such that complexity of 1 sieve in dim sieve_dim is approx
                 # the same as the BKZ call
                 sieve_dim = min(
                     d, floor(beta_ + log((d - beta) * C, 2) / self.NN_AGPS[self.nn]["a"])

--- a/estimator/reduction.py
+++ b/estimator/reduction.py
@@ -262,7 +262,7 @@ class ReductionCost:
         :param B: Bit-size of entries.
         :param preprocess: Include the cost of preprocessing the basis with BKZ-β.
                If ``False`` we assume the basis is already BKZ-β reduced.
-        :returns: ``(ρ, c, N)``
+        :return: ``(ρ, c, N, β')``
 
         EXAMPLES::
 
@@ -313,7 +313,7 @@ class ReductionCost:
         :param N: Number of vectors requested.
         :param B: Bit-size of entries.
         :param preprocess: This option is ignore.
-        :returns: ``(ρ, c, N)``
+        :return: ``(ρ, c, N, β')``
 
         EXAMPLES::
 
@@ -356,7 +356,7 @@ class ReductionCost:
         :param preprocess: Include the cost of preprocessing the basis with BKZ-β.
                If ``False`` we assume the basis is already BKZ-β reduced.
         :param sieve_dim: Explicit sieving dimension.
-        :returns: ``(ρ, c, N)``
+        :return: ``(ρ, c, N, β')``
 
         EXAMPLES::
 
@@ -767,6 +767,7 @@ class Kyber(ReductionCost):
           vector expected from an SVP oracle by this factor.
         - `c` is the cost of outputting `N` vectors
         - `N` the number of vectors output, which may be larger than the value put in for `N`.
+        - `β'` the cost parameter associated with sampling
 
         This is using an observation insprired by [AC:GuoJoh21]_ that we can run a sieve on the
         first block of the basis with negligible overhead.
@@ -776,30 +777,31 @@ class Kyber(ReductionCost):
         :param N: Number of vectors requested.
         :param preprocess: Include the cost of preprocessing the basis with BKZ-β.
                If ``False`` we assume the basis is already BKZ-β reduced.
+        :return: ``(ρ, c, N, β')``
 
         EXAMPLES::
 
             >>> from estimator.reduction import RC
             >>> RC.Kyber.short_vectors(100, 500, 1)
-            (1.0, 2.7367476128136...19, 100)
+            (1.0, 2.7367476128136...19, 100, 1)
             >>> RC.Kyber.short_vectors(100, 500)
-            (1.1547, 2.7367476128136...19, 176584)
+            (1.1547, 2.7367476128136...19, 176584, 84)
             >>> RC.Kyber.short_vectors(100, 500, 1000)
-            (1.1547, 2.7367476128136...19, 176584)
+            (1.1547, 2.7367476128136...19, 176584, 84)
 
         """
         beta_ = beta - floor(self.d4f(beta))
 
         if N == 1:
             if preprocess:
-                return 1.0, self(beta, d, B=B), beta
+                return 1.0, self(beta, d, B=B), beta, 1
             else:
-                return 1.0, 1, beta
+                return 1.0, 1, beta, 1
         elif N is None:
             N = floor(2 ** (0.2075 * beta_))  # pick something
 
         c = N / floor(2 ** (0.2075 * beta_))
-        return 1.1547, ceil(c) * self(beta, d), ceil(c) * floor(2 ** (0.2075 * beta_))
+        return 1.1547, ceil(c) * self(beta, d), ceil(c) * floor(2 ** (0.2075 * beta_)), beta_
 
 
 class GJ21(Kyber):
@@ -830,6 +832,7 @@ class GJ21(Kyber):
         :param B: Bit-size of entries.
         :param C: Progressive overhead lim_{β → ∞} ∑_{i ≤ β} 2^{0.292 i + o(i)}/2^{0.292 β + o(β)}.
         :param sieve_dim: Explicit sieving dimension.
+        :return: ``(ρ, c, N, β')``
 
         EXAMPLES::
 

--- a/estimator/util.py
+++ b/estimator/util.py
@@ -315,11 +315,11 @@ def binary_search(
     """
     Searches for the best value in the interval [start,stop] depending on the given comparison function.
 
-    :param start: start of range to search
-    :param stop: stop of range to search (exclusive)
+    :param start: start of range to search (inclusive)
+    :param stop: stop of range to search (inclusive)
     :param param: the parameter to modify when calling `f`
     :param smallerf: comparison is performed by evaluating ``smallerf(current, best)``
-    :param step: initially only consider every `steps`-th value
+    :param step: initially only consider every `step`-th value
     """
 
     with local_minimum(start, stop + 1, step, smallerf=smallerf, log_level=log_level) as it:

--- a/param_sweep.py
+++ b/param_sweep.py
@@ -88,9 +88,9 @@ class ParameterSweep:
                     num_proc=1,\
                 )
             usvp                 :: rop: ≈2^45.6, red: ≈2^45.6, δ: 1.007290, β: 156, d: 1120, tag: usvp
-            dual_hybrid          :: rop: ≈2^46.6, mem: ≈2^42.7, m: 579, β: 159, d: 1169, ↻: 1, ζ: 10, tag: dual_hybrid
+            dual_hybrid          :: rop: ≈2^46.6, mem: ≈2^42.9, m: 579, β: 159, d: 1169, ↻: 1, ζ: 10, tag: dual_hybrid
             usvp                 :: rop: ≈2^51.7, red: ≈2^51.7, δ: 1.006767, β: 177, d: 1124, tag: usvp
-            dual_hybrid          :: rop: ≈2^52.7, mem: ≈2^48.3, m: 571, β: 180, d: 1160, ↻: 1, ζ: 11, tag: dual_hybrid
+            dual_hybrid          :: rop: ≈2^52.7, mem: ≈2^48.4, m: 571, β: 180, d: 1160, ↻: 1, ζ: 11, tag: dual_hybrid
             usvp                 :: rop: ≈2^82.9, red: ≈2^82.9, δ: 1.005021, β: 284, d: 1661, tag: usvp
             dual_hybrid          :: rop: ≈2^83.0, mem: ≈2^77.8, m: 830, β: 284, d: 1711, ↻: 1, ζ: 19, tag: dual_hybrid
             usvp                 :: rop: ≈2^92.6, red: ≈2^92.6, δ: 1.004667, β: 317, d: 1650, tag: usvp


### PR DESCRIPTION
Resolves #88 

- The parameter `use_lll` in `lwe_dual.py` was unused.
- The `short_vectors` methods in `reduction.py` now consistently return a 4-tuple, containing sieving dimension.
- The memory cost of dual attack considers memory for storing the dual vectors, **AND** the FFT table.
- The runtime cost also takes into account building the initial FFT table, based on all the enumeration targets.
- Various typo fixes.
- Added note that the number of dual vectors required is assuming the Independence Heuristic.