### PR TITLE
BDD / Hybrid-BDD speed improvement for FHE-sized parameters

### DIFF
--- a/estimator/lwe_primal.py
+++ b/estimator/lwe_primal.py
@@ -602,10 +602,14 @@ class PrimalHybrid:
             usvp_cost = primal_usvp(params, red_cost_model=red_cost_model)["rop"]
             zeta_max = 1
             while zeta_max < params.n:
-                if params.Xs.support_size(zeta_max) > usvp_cost:
-                    # double it for mitm
-                    return 2 * zeta_max
-                zeta_max +=1
+                # TODO: once support_size() is supported for NTRU, remove the below try/except
+                try:
+                    if params.Xs.support_size(zeta_max) > usvp_cost:
+                        # double it for mitm
+                        return 2 * zeta_max
+                    zeta_max +=1
+                except ValueError:
+                    pass
             return params.n
 
         if zeta is None:

--- a/estimator/lwe_primal.py
+++ b/estimator/lwe_primal.py
@@ -610,7 +610,7 @@ class PrimalHybrid:
 
         if zeta is None:
             zeta_max = find_zeta_max(params, red_cost_model)
-            with local_minimum(0, zeta_max, log_level=log_level) as it:
+            with local_minimum(0, min(zeta_max, params.n), log_level=log_level) as it:
                 for zeta in it:
                     it.update(
                         f(

--- a/estimator/lwe_primal.py
+++ b/estimator/lwe_primal.py
@@ -608,8 +608,8 @@ class PrimalHybrid:
                         # double it for mitm
                         return 2 * zeta_max
                     zeta_max +=1
-                except ValueError:
-                    pass
+                except NotImplementedError:
+                    return params.n
             return params.n
 
         if zeta is None:

--- a/estimator/lwe_primal.py
+++ b/estimator/lwe_primal.py
@@ -303,8 +303,8 @@ class PrimalHybrid:
 
         if d > 4096:
             for i, _ in enumerate(r):
-                # chosen arbitrarily
-                j = d - 1024 + i
+                # chosen since RC.ADPS16(1754, 1754).log(2.) = 512.168000000000
+                j = d - 1754 + i
                 if gaussian_heuristic_log_input(r[j:]) < D.stddev**2 * (d - j):
                     return ZZ(d - (j - 1))
             return ZZ(2)


### PR DESCRIPTION
**For BDD**
Before:

```
sage: %time LWE.primal_bdd(schemes.SEAL22_32768.updated(n = 65536, q = 2**(2*log(schemes.SEAL22_32768.q))))
CPU times: user 50min 50s, sys: 35.5 s, total: 51min 25s
Wall time: 51min 33s
rop: ≈2^186.3, red: ≈2^186.3, svp: ≈2^176.1, β: 531, η: 555, d: 127471, tag: bdd
```

After:
```
sage: sage: %time LWE.primal_bdd(schemes.SEAL22_32768.updated(n = 65536, q = 2**(2*log(schemes.SEAL22_32768.q))))
CPU times: user 36.4 s, sys: 633 ms, total: 37 s
Wall time: 37.3 s
rop: ≈2^186.3, red: ≈2^186.3, svp: ≈2^176.1, β: 531, η: 555, d: 127471, tag: bdd
```
The idea is that checking for the required SVP dimension from from `0` to `n` isn't needed, and we can check from `0` to some other value much smaller than `n` (arbitrarily chosen for now). 

------------------------------------------------------------------------------------------------------------------
**For Hybrid-BDD**
Before:
```
sage: %time LWE.primal_hybrid(schemes.SEAL22_32768.updated(n = 65536, q = 2**(2*log(schemes.SEAL22_32768.q))))
CPU times: user 14min 36s, sys: 1min 42s, total: 16min 19s
Wall time: 17min 4s
rop: ≈2^251.0, red: ≈2^250.1, svp: ≈2^249.9, β: 531, η: 2, ζ: 192, |S|: ≈2^304.3, d: 130945, prob: ≈2^-61.5, ↻: ≈2^63.7, tag: hybrid
```

After:
```
sage: %time LWE.primal_hybrid(schemes.SEAL22_32768.updated(n = 65536, q = 2**(2*log(schemes.SEAL22_32768.q))))
zeta_max = 236
CPU times: user 3min 57s, sys: 4.22 s, total: 4min 1s
Wall time: 4min 2s
rop: ≈2^251.0, red: ≈2^250.1, svp: ≈2^249.9, β: 531, η: 2, ζ: 192, |S|: ≈2^304.3, d: 130945, prob: ≈2^-61.5, ↻: ≈2^63.7, tag: hybrid
```

The idea here is that the number of secret co-efficients guessed, `zeta`, doesn't need to be checked between `0` and `n` and can instead be searched for in some range `[0, zeta_max]`, where `zeta_max` is computed using a usvp estimate. A nice consequence of this change is that we can run hybrid attack estimates for very large values of `n` in a reasonable amount of time:

```
sage:  %time LWE.primal_hybrid(schemes.SEAL22_32768.updated(n = 132000, q = 2**(4*log(schemes.SEAL22_32768.q))))
CPU times: user 6min 53s, sys: 8.49 s, total: 7min 2s
Wall time: 7min 4s
rop: ≈2^441.0, red: ≈2^440.3, svp: ≈2^439.7, β: 535, η: 2, ζ: 239, |S|: ≈2^303.8, d: 263669, prob: ≈2^-249.6, ↻: ≈2^251.8, tag: hybrid
```