### PR TITLE
fix issue 102

### DIFF
--- a/estimator/lwe_primal.py
+++ b/estimator/lwe_primal.py
@@ -305,7 +305,7 @@ class PrimalHybrid:
             for i, _ in enumerate(r):
                 # chosen since RC.ADPS16(1754, 1754).log(2.) = 512.168000000000
                 j = d - 1754 + i
-                if gaussian_heuristic_log_input(r[j:]) < D.stddev**2 * (d - j):
+                if (j < d) and (gaussian_heuristic_log_input(r[j:]) < D.stddev**2 * (d - j)):
                     return ZZ(d - (j - 1))
             return ZZ(2)
 


### PR DESCRIPTION
Perhaps there is a better way to fix this, but the problem is that because we loop over `for i, _ in enumerate(r):`, the condition `gaussian_heuristic_log_input(r[j:])` (where `j = d - 1754 + i`) can be evaluated on an empty list if `j >= d`. Added an additional statement to stop this from occuring. Using the updated code we no longer get a bug as in #102 and instead see:

```
sage: from estimator import *
sage: quantum_model = RC.LaaMosPol14
....: param = LWE.Parameters(
....: n = 4096,
....: q = 2**(161) ,
....: Xs = ND.Uniform(-1, 1),
....: Xe = ND.DiscreteGaussian(3.19),
....: m = oo
....: )
sage:
sage: LWE.primal_hybrid(param, red_cost_model = quantum_model, mitm = False, babai = False)
rop: ≈2^79.3, red: ≈2^79.3, svp: ≈2^69.4, β: 177, η: 200, ζ: 0, |S|: 1, d: 8234, prob: 1, ↻: 1, tag: hybrid
```

the other three variants all run fine as well:

```
sage: LWE.primal_hybrid(param, red_cost_model = quantum_model, mitm = False, babai = True)
rop: ≈2^106.0, red: ≈2^105.4, svp: ≈2^104.4, β: 177, η: 2, ζ: 33, |S|: ≈2^52.3, d: 8201, prob: ≈2^-23.9, ↻: ≈2^26.1, tag: hybrid
sage: LWE.primal_hybrid(param, red_cost_model = quantum_model, mitm = True, babai = True)
rop: ≈2^122.3, red: ≈2^121.4, svp: ≈2^121.2, β: 177, η: 2, ζ: 67, |S|: ≈2^106.2, d: 8167, prob: ≈2^-39.9, ↻: ≈2^42.1, tag: hybrid
sage: LWE.primal_hybrid(param, red_cost_model = quantum_model, mitm = True, babai = False)
rop: ≈2^79.3, red: ≈2^79.3, svp: ≈2^69.4, β: 177, η: 200, ζ: 0, |S|: 1, d: 8234, prob: 1, ↻: 1, tag: hybrid
```