### PR TITLE
fix Issue 110

### DIFF
--- a/estimator/lwe_dual.py
+++ b/estimator/lwe_dual.py
@@ -591,6 +591,7 @@ class MATZOV:
             k_fft,
             p,
         )
+
         rho, T_sample, _, beta_sieve = red_cost_model.short_vectors(
             beta, N=N, d=k_lat + m, sieve_dim=beta_sieve
         )

--- a/estimator/reduction.py
+++ b/estimator/reduction.py
@@ -390,6 +390,11 @@ class ReductionCost:
             self.delta(sieve_dim) ** (sieve_dim - 1) * self.delta(beta) ** (1 - sieve_dim)
         )
 
+        #arbitrary choice
+        if c > 2**1000:
+            c = oo
+            return (rho, oo, oo, sieve_dim)
+
         return (
             rho,
             ceil(c) * self(beta, d),
@@ -883,7 +888,7 @@ class GJ21(Kyber):
         rho = sqrt(4 / 3.0) * RR(
             self.delta(sieve_dim) ** (sieve_dim - 1) * self.delta(beta) ** (1 - sieve_dim)
         )
-
+        
         if N == 1:
             if preprocess:
                 return 1.0, self(beta, d, B=B), 1, beta
@@ -892,8 +897,16 @@ class GJ21(Kyber):
         elif N is None:
             N = floor(2 ** (0.2075 * sieve_dim))  # pick something
 
-        c = N / floor(2 ** (0.2075 * sieve_dim))
-        sieve_cost = C * 2 ** (self.NN_AGPS[self.nn]["a"] * sieve_dim + self.NN_AGPS[self.nn]["b"])
+        c0 = RR(N)
+        c1 = RR(2 ** (0.2075 * sieve_dim))
+        c = c0 / floor(c1)
+        sieve_cost = C * 2 ** RR((self.NN_AGPS[self.nn]["a"] * sieve_dim + self.NN_AGPS[self.nn]["b"]))
+
+        #arbitrary choice
+        if c > 2**1000:
+            c = oo
+            return(rho, oo, oo, sieve_dim)
+
         return (
             rho,
             ceil(c) * (self(beta, d) + sieve_cost),

--- a/estimator/reduction.py
+++ b/estimator/reduction.py
@@ -390,7 +390,7 @@ class ReductionCost:
             self.delta(sieve_dim) ** (sieve_dim - 1) * self.delta(beta) ** (1 - sieve_dim)
         )
 
-        #arbitrary choice
+        # arbitrary choice
         if c > 2**1000:
             c = oo
             return (rho, oo, oo, sieve_dim)
@@ -888,7 +888,7 @@ class GJ21(Kyber):
         rho = sqrt(4 / 3.0) * RR(
             self.delta(sieve_dim) ** (sieve_dim - 1) * self.delta(beta) ** (1 - sieve_dim)
         )
-        
+
         if N == 1:
             if preprocess:
                 return 1.0, self(beta, d, B=B), 1, beta
@@ -902,10 +902,15 @@ class GJ21(Kyber):
         c = c0 / floor(c1)
         sieve_cost = C * 2 ** RR((self.NN_AGPS[self.nn]["a"] * sieve_dim + self.NN_AGPS[self.nn]["b"]))
 
-        #arbitrary choice
+        # arbitrary choice
         if c > 2**1000:
-            c = oo
-            return(rho, oo, oo, sieve_dim)
+            # set c = oo
+            return (
+                rho,
+                oo,
+                oo,
+                sieve_dim,
+            )
 
         return (
             rho,

--- a/estimator/reduction.py
+++ b/estimator/reduction.py
@@ -392,8 +392,13 @@ class ReductionCost:
 
         # arbitrary choice
         if c > 2**1000:
-            c = oo
-            return (rho, oo, oo, sieve_dim)
+            # set c = oo
+            return (
+                rho,
+                oo,
+                oo,
+                sieve_dim,
+            )
 
         return (
             rho,


### PR DESCRIPTION
**Issue 1.**
As in #110, the crash was caused by some missing `RR()s` which have been added below. After this, the code outlined in the issue runs but segfaults. The segfault happens for both `RC.BDGL16` and `RC.MATZOV`, but for different reasons.

**Issue 2.**
After fixing 1. Variants of `short_vectors()` are crashing for different cost models and causing a segfault, this happens when `c` in the below code is huge (e.g. `>2**large`). Basically, we are calling e.g. `ceil(2**large)` and it just crashes. To avoid this, I picked an arbitrary value and set c to `oo` in this case. The choice of the arbitrary value (`2**1000`) might need some discussion.

I also added a blankline to `lwe_dual.py` for readability.