### PR TITLE
include ChaLoy21 = ChaLoy21() in Class RC in reduction.py

### DIFF
--- a/estimator/reduction.py
+++ b/estimator/reduction.py
@@ -1011,3 +1011,4 @@ class RC:
     MATZOV = MATZOV()
     GJ21 = GJ21()
     LaaMosPol14 = LaaMosPol14()
+    ChaLoy21 = ChaLoy21()


### PR DESCRIPTION
Got error message: AttributeError: type object 'RC' has no attribute 'ChaLoy21' when selecting quantum cost model = RC.ChaLoy21.