### PR TITLE
bugfix(usvp): guess zeros in the case of a sparse secret

### DIFF
--- a/estimator/lwe.py
+++ b/estimator/lwe.py
@@ -124,13 +124,16 @@ class Estimate:
         if params.Xs.is_sparse:
             # guess zeros for uSVP if the secret is sparse
             algorithms["usvp"] = partial(
-                    partial(guess_composition.sparse_solve, primal_usvp), red_cost_model=red_cost_model, red_shape_model=red_shape_model
+                partial(guess_composition.sparse_solve, primal_usvp),
+                red_cost_model=red_cost_model,
+                red_shape_model=red_shape_model
             )
+
         else:
             algorithms["usvp"] = partial(
                 primal_usvp, red_cost_model=red_cost_model, red_shape_model=red_shape_model
             )
-            
+
         algorithms["bdd"] = partial(
             primal_bdd, red_cost_model=red_cost_model, red_shape_model=red_shape_model
         )

--- a/estimator/lwe.py
+++ b/estimator/lwe.py
@@ -121,9 +121,16 @@ class Estimate:
         algorithms["arora-gb"] = guess_composition(arora_gb)
         algorithms["bkw"] = coded_bkw
 
-        algorithms["usvp"] = partial(
-            primal_usvp, red_cost_model=red_cost_model, red_shape_model=red_shape_model
-        )
+        if params.Xs.is_sparse:
+            # guess zeros for uSVP if the secret is sparse
+            algorithms["usvp"] = partial(
+                    partial(guess_composition.sparse_solve, primal_usvp), red_cost_model=red_cost_model, red_shape_model=red_shape_model
+            )
+        else:
+            algorithms["usvp"] = partial(
+                primal_usvp, red_cost_model=red_cost_model, red_shape_model=red_shape_model
+            )
+            
         algorithms["bdd"] = partial(
             primal_bdd, red_cost_model=red_cost_model, red_shape_model=red_shape_model
         )


### PR DESCRIPTION
For sparse secrets we should default uSVP to guess zeros, e.g.:

```
params = schemes.TFHE1024.updated(Xs = ND.SparseTernary(1024,1,1))
```

gives default output (i.e. in `LWE.estimate`):

```
usvp:: rop: ≈2^108.1, red: ≈2^108.1, δ: 1.005154, β: 273, d: 1608, tag: usvp
```
since it is not explicitly calling `lwe_guess`. After this PR, `LWE.estimate` outputs:

```
usvp:: rop: ≈2^44.6, red: ≈2^44.6, δ: 1.012950, β: 40, d: 41, tag: usvp, ↻: ≈2^11.5, ζ: 983, |S|: 1, prop: 0
```
where we can see that guessing `ζ = 983` out of 1024 components is optimal. We could do something similar with the other attacks (`bdd, dual`, but this is kind-of covered in the hybrid attacks).
