### PR TITLE
Comment difference rough vs estimate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,14 +16,15 @@ Quick Start
 
 We currently provide evaluators for the security of the `LWE`, `NTRU`, and `SIS` problems. 
 Our estimator integrates simulators for the best known attacks against these problems, and provides
-bit-security estimates relying on heuristics to predict the cost of lattice reduction algorithms, the default being
-using `[MATZOV22] <https://zenodo.org/record/6412487>` for lattice reduction cost, and the GSA assumption 
-`[Schnorr03] <http://dx.doi.org/10.1007/3-540-36494-3_14>` for the reduction shape. 
+bit-security estimates relying on heuristics to predict the cost and shape of lattice reduction algorithms. The default
+models are configured in `conf.py <https://github.com/malb/lattice-estimator/blob/main/estimator/conf.py>`.
 
 It is possible to evaluate attacks cost individually, or using the helper functions:
 - `*.estimator.rough`: fast routine that evaluates the security of the problem only against the usually most efficient
-   attacks. In this case, note that the concrete lattice reduction cost is evaluated using the non-default "Core-SVP" method
-   from `[USENIX:ADPS16] <https://www.usenix.org/system/files/conference/usenixsecurity16/sec16_paper_alkim.pdf>`.
+   attacks. Note that it uses a non-default cost model for lattice reduction, most often used in the literature for ease of 
+   comparison, and will thus return different numbers than the rest of the API. Refer to 
+   `its documentation <https://lattice-estimator.readthedocs.io/en/latest/_apidoc/estimator.lwe/estimator.lwe.Estimate/estimator.lwe.Estimate.rough.html>` 
+   for details.
 - `*.estimator`: extended routine that evaluates the security of the problem against all supported attacks. This uses the
    default cost and shape model for lattice reduction.
 

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,20 @@ The main purpose of this estimator is to give designers an easy way to choose pa
 Quick Start
 -----------
 
-- Usage
+We currently provide evaluators for the security of the `LWE`, `NTRU`, and `SIS` problems. 
+Our estimator integrates simulators for the best known attacks against these problems, and provides
+bit-security estimates relying on heuristics to predict the cost of lattice reduction algorithms, the default being
+using `[MATZOV22] <https://zenodo.org/record/6412487>` for lattice reduction cost, and the GSA assumption 
+`[Schnorr03] <http://dx.doi.org/10.1007/3-540-36494-3_14>` for the reduction shape. 
+
+It is possible to evaluate attacks cost individually, or using the helper functions:
+- `*.estimator.rough`: fast routine that evaluates the security of the problem only against the usually most efficient
+   attacks. In this case, note that the concrete lattice reduction cost is evaluated using the non-default "Core-SVP" method
+   from `[USENIX:ADPS16] <https://www.usenix.org/system/files/conference/usenixsecurity16/sec16_paper_alkim.pdf>`.
+- `*.estimator`: extended routine that evaluates the security of the problem against all supported attacks. This uses the
+   default cost and shape model for lattice reduction.
+
+Usage examples:
 
   .. code-block:: python
     

--- a/docs/algorithms/lwe-dual.rst
+++ b/docs/algorithms/lwe-dual.rst
@@ -22,6 +22,6 @@ Further improvements are possible using a meet-in-the-middle approach [EPRINT:CH
 
    dual_hybrid(params, mitm_optimization=True)
 
-We consider the variant fron [MATZOV22]_::
+We consider the variant from [MATZOV22]_::
 
    matzov(params)

--- a/docs/algorithms/sis-lattice.rst
+++ b/docs/algorithms/sis-lattice.rst
@@ -32,5 +32,5 @@ Another option is to simulate a rerandomization of the basis, such that the q-ve
 
     SIS.lattice(params.updated(length_bound=70), red_shape_model=Simulator.LGSA)
 
-**Note:** Currently, lattice attack estimation is only avalailable for euclidean (``2``) and infinity (``oo``) norms. ``SIS.lattice()`` will return a ``NotImplementedError`` if one of these two norms are not selected.
+**Note:** Currently, lattice attack estimation is only available for euclidean (``2``) and infinity (``oo``) norms. ``SIS.lattice()`` will return a ``NotImplementedError`` if one of these two norms are not selected.
                         

--- a/estimator/conf.py
+++ b/estimator/conf.py
@@ -7,10 +7,15 @@ from .simulator import GSA
 from .reduction import RC
 from sage.all import exp
 
+"""
+Default models used to evaluate the cost and shape of lattice reduction.
+This influences the concrete estimated cost of attacks.
+"""
 red_cost_model = RC.MATZOV
 red_cost_model_classical_poly_space = RC.ABLR21
 red_shape_model = "gsa"
 red_simulator = GSA
+
 mitm_opt = "analytical"
 max_n_cache = 10000
 

--- a/estimator/lwe.py
+++ b/estimator/lwe.py
@@ -25,10 +25,13 @@ class Estimate:
 
     def rough(self, params, jobs=1, catch_exceptions=True):
         """
-        This function makes the following somewhat routine assumptions:
+        This function makes the following (non-default) somewhat routine assumptions to evaluate the cost of lattice 
+        reduction, and to provide comparable numbers with most of the literature:
 
         - The GSA holds.
         - The Core-SVP model holds.
+
+        Provided numbers are notably not directly comparable with the rest of our API, when using the default cost models.
 
         This function furthermore assumes the following heuristics:
 
@@ -36,9 +39,6 @@ class Estimate:
         - The dual hybrid MITM attack only applies to sparse secrets.
         - Arora-GB only applies to bounded noise with at least `n^2` samples.
         - BKW is not competitive.
-
-        Lattice reduction cost is evaluated based on the non-default "Core-SVP" method from
-        [USENIX:ADPS16].
 
         :param params: LWE parameters.
         :param jobs: Use multiple threads in parallel.
@@ -96,7 +96,7 @@ class Estimate:
         catch_exceptions=True,
     ):
         """
-        Run all estimates.
+        Run all estimates, based on the default cost and shape models for lattice reduction.
 
         :param params: LWE parameters.
         :param red_cost_model: How to cost lattice reduction.

--- a/estimator/lwe.py
+++ b/estimator/lwe.py
@@ -25,13 +25,14 @@ class Estimate:
 
     def rough(self, params, jobs=1, catch_exceptions=True):
         """
-        This function makes the following (non-default) somewhat routine assumptions to evaluate the cost of lattice 
+        This function makes the following (non-default) somewhat routine assumptions to evaluate the cost of lattice
         reduction, and to provide comparable numbers with most of the literature:
 
         - The GSA holds.
         - The Core-SVP model holds.
 
-        Provided numbers are notably not directly comparable with the rest of our API, when using the default cost models.
+        Provided numbers are notably not directly comparable with the rest of our API, when using the default cost
+        models.
 
         This function furthermore assumes the following heuristics:
 

--- a/estimator/lwe.py
+++ b/estimator/lwe.py
@@ -37,6 +37,9 @@ class Estimate:
         - Arora-GB only applies to bounded noise with at least `n^2` samples.
         - BKW is not competitive.
 
+        Lattice reduction cost is evaluated based on the non-default "Core-SVP" method from
+        [USENIX:ADPS16].
+
         :param params: LWE parameters.
         :param jobs: Use multiple threads in parallel.
         :param catch_exceptions: When an estimate fails, just print a warning.

--- a/estimator/ntru.py
+++ b/estimator/ntru.py
@@ -33,6 +33,9 @@ class Estimate:
         - The dual hybrid MITM attack only applies to sparse secrets.
         - The dense sublattice attack only applies to possibly overstretched parameters
 
+        Lattice reduction cost is evaluated based on the non-default "Core-SVP" method from
+        [USENIX:ADPS16].
+
         :param params: NTRU parameters.
         :param jobs: Use multiple threads in parallel.
         :param catch_exceptions: When an estimate fails, just print a warning.

--- a/estimator/ntru.py
+++ b/estimator/ntru.py
@@ -22,13 +22,14 @@ class Estimate:
 
     def rough(self, params, jobs=1, catch_exceptions=True):
         """
-        This function makes the following (non-default) somewhat routine assumptions to evaluate the cost of lattice 
+        This function makes the following (non-default) somewhat routine assumptions to evaluate the cost of lattice
         reduction, and to provide comparable numbers with most of the literature:
 
         - The ZGSA holds.
         - The Core-SVP model holds.
 
-        Provided numbers are notably not directly comparable with the rest of our API, when using the default cost models.
+        Provided numbers are notably not directly comparable with the rest of our API, when using the default cost
+        models.
 
         This function furthermore assumes the following heuristics:
 

--- a/estimator/ntru.py
+++ b/estimator/ntru.py
@@ -22,19 +22,19 @@ class Estimate:
 
     def rough(self, params, jobs=1, catch_exceptions=True):
         """
-        This function makes the following somewhat routine assumptions:
+        This function makes the following (non-default) somewhat routine assumptions to evaluate the cost of lattice 
+        reduction, and to provide comparable numbers with most of the literature:
 
         - The ZGSA holds.
         - The Core-SVP model holds.
+
+        Provided numbers are notably not directly comparable with the rest of our API, when using the default cost models.
 
         This function furthermore assumes the following heuristics:
 
         - The primal hybrid attack only applies to sparse secrets.
         - The dual hybrid MITM attack only applies to sparse secrets.
         - The dense sublattice attack only applies to possibly overstretched parameters
-
-        Lattice reduction cost is evaluated based on the non-default "Core-SVP" method from
-        [USENIX:ADPS16].
 
         :param params: NTRU parameters.
         :param jobs: Use multiple threads in parallel.
@@ -94,7 +94,7 @@ class Estimate:
         catch_exceptions=True,
     ):
         """
-        Run all estimates.
+        Run all estimates, based on the default cost and shape models for lattice reduction.
 
         :param params: NTRU parameters.
         :param red_cost_model: How to cost lattice reduction.

--- a/estimator/sis.py
+++ b/estimator/sis.py
@@ -19,13 +19,14 @@ from .reduction import RC
 class Estimate:
     def rough(self, params, jobs=1, catch_exceptions=True):
         """
-        This function makes the following (non-default) somewhat routine assumptions to evaluate the cost of lattice 
+        This function makes the following (non-default) somewhat routine assumptions to evaluate the cost of lattice
         reduction, and to provide comparable numbers with most of the literature:
 
         - The LGSA holds.
         - The Core-SVP model holds.
 
-        Provided numbers are notably not directly comparable with the rest of our API, when using the default cost models.
+        Provided numbers are notably not directly comparable with the rest of our API, when using the default cost
+        models.
 
         This function furthermore assumes the following heuristics:
         - None at the moment. May change as more algorithms are added.

--- a/estimator/sis.py
+++ b/estimator/sis.py
@@ -19,16 +19,16 @@ from .reduction import RC
 class Estimate:
     def rough(self, params, jobs=1, catch_exceptions=True):
         """
-        This function makes the following somewhat routine assumptions:
+        This function makes the following (non-default) somewhat routine assumptions to evaluate the cost of lattice 
+        reduction, and to provide comparable numbers with most of the literature:
 
         - The LGSA holds.
         - The Core-SVP model holds.
 
+        Provided numbers are notably not directly comparable with the rest of our API, when using the default cost models.
+
         This function furthermore assumes the following heuristics:
         - None at the moment. May change as more algorithms are added.
-
-        Lattice reduction cost is evaluated based on the non-default "Core-SVP" method from
-        [USENIX:ADPS16].
 
         :param params: SIS parameters.
         :param jobs: Use multiple threads in parallel.
@@ -77,7 +77,7 @@ class Estimate:
         catch_exceptions=True,
     ):
         """
-        Run all estimates.
+        Run all estimates, based on the default cost and shape models for lattice reduction.
 
         :param params: SIS parameters.
         :param red_cost_model: How to cost lattice reduction.

--- a/estimator/sis.py
+++ b/estimator/sis.py
@@ -27,6 +27,9 @@ class Estimate:
         This function furthermore assumes the following heuristics:
         - None at the moment. May change as more algorithms are added.
 
+        Lattice reduction cost is evaluated based on the non-default "Core-SVP" method from
+        [USENIX:ADPS16].
+
         :param params: SIS parameters.
         :param jobs: Use multiple threads in parallel.
         :param catch_exceptions: When an estimate fails, just print a warning.


### PR DESCRIPTION
Following a private email discussion with Martin and others, I would suggest adding a comment in the README about the main API and the cost models in use throughout the codebase.

I was quite confused that `rough` uses [ADPS16] by default, but the rest of the code rather relies on [MATZOV] for the concrete cost of lattice reduction.