### PR TITLE
fix(log): bypass ValueError 

### DIFF
--- a/estimator/lwe_primal.py
+++ b/estimator/lwe_primal.py
@@ -287,7 +287,8 @@ class PrimalHybrid:
         :param r: squared Gram-Schmidt norms
 
         """
-        from math import lgamma, log, exp, pi
+        from math import lgamma, exp, pi
+        from math import log as math_log
 
         def ball_log_vol(n):
             return (n / 2.0) * log(pi) - lgamma(n / 2.0 + 1)
@@ -299,7 +300,13 @@ class PrimalHybrid:
             return exp(log_gh)
 
         d = len(r)
-        r = [log(x) for x in r]
+
+        try:
+            r = [math_log(x) for x in r]
+
+        except:
+            # use slower one when the above crashes due to small values
+            r = [log(x) for x in r]
 
         if d > 4096:
             for i, _ in enumerate(r):

--- a/estimator/lwe_primal.py
+++ b/estimator/lwe_primal.py
@@ -287,8 +287,7 @@ class PrimalHybrid:
         :param r: squared Gram-Schmidt norms
 
         """
-        from math import lgamma, exp, pi
-        from math import log as math_log
+        from math import lgamma, exp, pi, log as math_log
 
         def ball_log_vol(n):
             return (n / 2.0) * log(pi) - lgamma(n / 2.0 + 1)
@@ -304,7 +303,7 @@ class PrimalHybrid:
         try:
             r = [math_log(x) for x in r]
 
-        except:
+        except ValueError:
             # use slower one when the above crashes due to small values
             r = [log(x) for x in r]
 


### PR DESCRIPTION
Fixes #128 

The `sage.all.log()` function does not throw the same error found in `math.log()`, so can be used as a bypass. However, it's much slower (~50x in some cases) so I did not just directly swap it out.

It's a bit unsatisfactory, though, but it works. 