### PR TITLE
Add TUniform distribution

### DIFF
--- a/estimator/nd.py
+++ b/estimator/nd.py
@@ -380,6 +380,58 @@ class Uniform(NoiseDistribution):
         a, b = self.bounds
         return ceil(RR(fraction) * (b - a + 1)**len(self))
 
+class TUniform(NoiseDistribution):
+    """
+    TUniform distribution ∈ ``ZZ ∩ [-2**b, 2**b]``, endpoints inclusive. 
+    This distribution samples the two end-points with probability 1/2**(b+2) and the
+    intermediate points with probability 1/2**(b+1). 
+
+    As an example, with b=0 this distribution samples ±1 each with probability 1/4 and
+    0 with probability 1/2.
+
+    EXAMPLE::
+
+        >>> from estimator import *
+        >>> ND.TUniform(0)
+        D(σ=0.82)
+        >>> ND.TUniform(10)
+        D(σ=591.50)
+    """
+    def __init__(self, b, n=None):
+        b = int(ceil(b))
+        a = - b
+        m = b - a + 1
+
+        super().__init__(
+            n=n,
+            mean=RR(0),
+            stddev=RR(sqrt(((2**(b+1) + 1)**2 - 1)/12)),
+            bounds=(-2**b, 2**b),
+            _density=(1 - 1 / 2**(b+1)),
+        )
+
+    def __hash__(self):
+        """
+        EXAMPLE::
+
+            >>> from estimator import *
+            >>> hash(ND.TUniform(2)) == hash(("TUniform", (-4, 4), None))
+            True
+        """
+        return hash(("TUniform", self.bounds, self.n))
+
+    def support_size(self, fraction=1.0):
+        """
+        Compute the size of the support covering the probability given as fraction.
+
+        EXAMPLE::
+
+            >>> from estimator import *
+            >>> ND.TUniform(0, 64).support_size(0.99)
+            3399346982089587232319333203968
+        """
+        a, b = self.bounds
+        return ceil(RR(fraction) * (b - a + 1)**len(self))
 
 def UniformMod(q, n=None):
     """

--- a/estimator/nd.py
+++ b/estimator/nd.py
@@ -380,11 +380,31 @@ class Uniform(NoiseDistribution):
         a, b = self.bounds
         return ceil(RR(fraction) * (b - a + 1)**len(self))
 
+
+def UniformMod(q, n=None):
+    """
+    Uniform mod ``q``, with balanced representation, i.e. values in ZZ ∩ [-q/2, q/2).
+
+    EXAMPLE::
+
+        >>> from estimator import *
+        >>> ND.UniformMod(7)
+        D(σ=2.00)
+        >>> ND.UniformMod(8)
+        D(σ=2.29, μ=-0.50)
+        >>> ND.UniformMod(2) == ND.Uniform(-1, 0)
+        True
+    """
+    a = -(q // 2)
+    b = a + q - 1
+    return Uniform(a, b, n=n)
+
+
 class TUniform(NoiseDistribution):
     """
-    TUniform distribution ∈ ``ZZ ∩ [-2**b, 2**b]``, endpoints inclusive. 
+    TUniform distribution ∈ ``ZZ ∩ [-2**b, 2**b]``, endpoints inclusive.
     This distribution samples the two end-points with probability 1/2**(b+2) and the
-    intermediate points with probability 1/2**(b+1). 
+    intermediate points with probability 1/2**(b+1).
 
     As an example, with b=0 this distribution samples ±1 each with probability 1/4 and
     0 with probability 1/2.
@@ -399,8 +419,6 @@ class TUniform(NoiseDistribution):
     """
     def __init__(self, b, n=None):
         b = int(ceil(b))
-        a = - b
-        m = b - a + 1
 
         super().__init__(
             n=n,
@@ -432,24 +450,6 @@ class TUniform(NoiseDistribution):
         """
         a, b = self.bounds
         return ceil(RR(fraction) * (b - a + 1)**len(self))
-
-def UniformMod(q, n=None):
-    """
-    Uniform mod ``q``, with balanced representation, i.e. values in ZZ ∩ [-q/2, q/2).
-
-    EXAMPLE::
-
-        >>> from estimator import *
-        >>> ND.UniformMod(7)
-        D(σ=2.00)
-        >>> ND.UniformMod(8)
-        D(σ=2.29, μ=-0.50)
-        >>> ND.UniformMod(2) == ND.Uniform(-1, 0)
-        True
-    """
-    a = -(q // 2)
-    b = a + q - 1
-    return Uniform(a, b, n=n)
 
 
 class SparseTernary(NoiseDistribution):


### PR DESCRIPTION
Adding the TUniform distribution which is used in the tfhe-rs library (as well as other FHE schemes, such as BGV/CKKS). This is essentially a generalisation (consider `b=0`) of the distribution which samples:

```
-1 with prob 1/4
1 with prob 1/4
0 with prob 1/2
```

which is commonly mixed up with the uniform ternary distribution. More generically, the distribution `TUniform(-2**b, 2**b)` samples:

```
-2**b, 2**b each with probability 1/2**(b+2)
the other terms with probability 1/2**(b+1)
```

For small values of `b`, the associated standard deviation is different enough from the `Uniform()` distribution that it is worth including both. 