### PR TITLE
Correct trivial SIS cases in sis_lattice.py

### DIFF
--- a/estimator/sis_lattice.py
+++ b/estimator/sis_lattice.py
@@ -55,8 +55,8 @@ class SISLattice:
         **kwds,
     ):
         # Check for triviality
-        if params.length_bound >= sqrt(params.m) * (params.q / 2):
-            raise ValueError("SIS trivially easy. Please set norm bound < √{m}⋅q/2.")
+        if params.length_bound >= (params.q-1) / 2:
+            raise ValueError("SIS trivially easy. Please set norm bound < (q-1)/2.")
 
         if d is None:
             d = min(floor(SISLattice._opt_sis_d(params)), params.m)
@@ -104,8 +104,8 @@ class SISLattice:
             it merely reports costs.
 
         """
-        if params.length_bound >= params.q:
-            raise ValueError("SIS trivially easy. Please set norm bound < q.")
+        if params.length_bound >= (params.q-1)/2:
+            raise ValueError("SIS trivially easy. Please set norm bound < (q-1)/2.")
 
         if d is None:
             d = params.m


### PR DESCRIPTION
A(q*e1) = 0 mod q is a trivial solution for when the input bound is >= q for both l_2 and l_inf norms. In the centered representation we're using signed modulus range [-(q-1)/2,(q-1)/2] as clarified in https://github.com/malb/lattice-estimator/issues/111