### PR TITLE
adding verbose flag to Estimate classes (LWE, NTRU, SIS)

### DIFF
--- a/estimator/lwe.py
+++ b/estimator/lwe.py
@@ -23,7 +23,7 @@ from .reduction import RC
 
 class Estimate:
 
-    def rough(self, params, jobs=1, catch_exceptions=True):
+    def rough(self, params, jobs=1, catch_exceptions=True, verbose=True):
         """
         This function makes the following (non-default) somewhat routine assumptions to evaluate the cost of lattice
         reduction, and to provide comparable numbers with most of the literature:
@@ -44,6 +44,7 @@ class Estimate:
         :param params: LWE parameters.
         :param jobs: Use multiple threads in parallel.
         :param catch_exceptions: When an estimate fails, just print a warning.
+        :param verbose: If True, prints cost estimates to stdout.
 
         EXAMPLE ::
 
@@ -77,12 +78,13 @@ class Estimate:
             if f_name(attack) == k
         }
 
-        for algorithm in algorithms:
-            if algorithm not in res:
-                continue
-            result = res[algorithm]
-            if result["rop"] != oo:
-                print(f"{algorithm:20s} :: {result!r}")
+        if verbose:
+            for algorithm in algorithms:
+                if algorithm not in res:
+                    continue
+                result = res[algorithm]
+                if result["rop"] != oo:
+                    print(f"{algorithm:20s} :: {result!r}")
 
         return res
 
@@ -95,6 +97,7 @@ class Estimate:
         add_list=tuple(),
         jobs=1,
         catch_exceptions=True,
+        verbose=True
     ):
         """
         Run all estimates, based on the default cost and shape models for lattice reduction.
@@ -106,6 +109,7 @@ class Estimate:
         :param add_list: add these ``(name, function)`` pairs to the list of algorithms to estimate.a
         :param jobs: Use multiple threads in parallel.
         :param catch_exceptions: When an estimate fails, just print a warning.
+        :param verbose: If True, prints cost estimates to stdout.
 
         EXAMPLE ::
 
@@ -163,19 +167,20 @@ class Estimate:
             if f_name(attack) == k
         }
 
-        for algorithm in algorithms:
-            if algorithm not in res:
-                continue
-            result = res[algorithm]
-            if result["rop"] == oo:
-                continue
-            if algorithm == "bdd_hybrid" and res["bdd"]["rop"] <= result["rop"]:
-                continue
-            if algorithm == "bdd_mitm_hybrid" and res["bdd_hybrid"]["rop"] <= result["rop"]:
-                continue
-            if algorithm == "dual_mitm_hybrid" and res["dual_hybrid"]["rop"] < result["rop"]:
-                continue
-            print(f"{algorithm:20s} :: {result!r}")
+        if verbose:
+            for algorithm in algorithms:
+                if algorithm not in res:
+                    continue
+                result = res[algorithm]
+                if result["rop"] == oo:
+                    continue
+                if algorithm == "bdd_hybrid" and res["bdd"]["rop"] <= result["rop"]:
+                    continue
+                if algorithm == "bdd_mitm_hybrid" and res["bdd_hybrid"]["rop"] <= result["rop"]:
+                    continue
+                if algorithm == "dual_mitm_hybrid" and res["dual_hybrid"]["rop"] < result["rop"]:
+                    continue
+                print(f"{algorithm:20s} :: {result!r}")
 
         return res
 

--- a/estimator/ntru.py
+++ b/estimator/ntru.py
@@ -20,7 +20,7 @@ from .reduction import RC
 
 class Estimate:
 
-    def rough(self, params, jobs=1, catch_exceptions=True):
+    def rough(self, params, jobs=1, catch_exceptions=True, verbose=True):
         """
         This function makes the following (non-default) somewhat routine assumptions to evaluate the cost of lattice
         reduction, and to provide comparable numbers with most of the literature:
@@ -40,6 +40,7 @@ class Estimate:
         :param params: NTRU parameters.
         :param jobs: Use multiple threads in parallel.
         :param catch_exceptions: When an estimate fails, just print a warning.
+        :param verbose: If True, prints cost estimates to stdout.
 
         EXAMPLE ::
 
@@ -80,12 +81,13 @@ class Estimate:
             if f_name(attack) == k
         }
 
-        for algorithm in algorithms:
-            if algorithm not in res:
-                continue
-            result = res[algorithm]
-            if result["rop"] != oo:
-                print(f"{algorithm:20s} :: {result!r}")
+        if verbose:
+            for algorithm in algorithms:
+                if algorithm not in res:
+                    continue
+                result = res[algorithm]
+                if result["rop"] != oo:
+                    print(f"{algorithm:20s} :: {result!r}")
 
         return res
 
@@ -98,6 +100,7 @@ class Estimate:
         add_list=tuple(),
         jobs=1,
         catch_exceptions=True,
+        verbose=True
     ):
         """
         Run all estimates, based on the default cost and shape models for lattice reduction.
@@ -109,6 +112,7 @@ class Estimate:
         :param add_list: add these ``(name, function)`` pairs to the list of algorithms to estimate.a
         :param jobs: Use multiple threads in parallel.
         :param catch_exceptions: When an estimate fails, just print a warning.
+        :param verbose: If True, prints cost estimates to stdout.
 
         EXAMPLE ::
 
@@ -170,17 +174,19 @@ class Estimate:
             for k, v in res_raw.items()
             if f_name(attack) == k
         }
-        for algorithm in algorithms:
-            if algorithm not in res:
-                continue
-            result = res[algorithm]
-            if result["rop"] == oo:
-                continue
-            if algorithm == "hybrid" and res["bdd"]["rop"] < result["rop"]:
-                continue
-            if algorithm == "dsd" and res["usvp"]["rop"] < result["rop"]:
-                continue
-            print(f"{algorithm:20s} :: {result!r}")
+
+        if verbose:
+            for algorithm in algorithms:
+                if algorithm not in res:
+                    continue
+                result = res[algorithm]
+                if result["rop"] == oo:
+                    continue
+                if algorithm == "hybrid" and res["bdd"]["rop"] < result["rop"]:
+                    continue
+                if algorithm == "dsd" and res["usvp"]["rop"] < result["rop"]:
+                    continue
+                print(f"{algorithm:20s} :: {result!r}")
 
         return res
 

--- a/estimator/sis.py
+++ b/estimator/sis.py
@@ -17,7 +17,7 @@ from .reduction import RC
 
 
 class Estimate:
-    def rough(self, params, jobs=1, catch_exceptions=True):
+    def rough(self, params, jobs=1, catch_exceptions=True, verbose=True):
         """
         This function makes the following (non-default) somewhat routine assumptions to evaluate the cost of lattice
         reduction, and to provide comparable numbers with most of the literature:
@@ -34,6 +34,7 @@ class Estimate:
         :param params: SIS parameters.
         :param jobs: Use multiple threads in parallel.
         :param catch_exceptions: When an estimate fails, just print a warning.
+        :param verbose: If True, prints cost estimates to stdout.
 
         EXAMPLE ::
 
@@ -58,12 +59,13 @@ class Estimate:
             if f_name(attack) == k
         }
 
-        for algorithm in algorithms:
-            if algorithm not in res:
-                continue
-            result = res[algorithm]
-            if result["rop"] != oo:
-                print(f"{algorithm:8s} :: {result!r}")
+        if verbose:
+            for algorithm in algorithms:
+                if algorithm not in res:
+                    continue
+                result = res[algorithm]
+                if result["rop"] != oo:
+                    print(f"{algorithm:8s} :: {result!r}")
 
         return res
 
@@ -76,6 +78,7 @@ class Estimate:
         add_list=tuple(),
         jobs=1,
         catch_exceptions=True,
+        verbose=True
     ):
         """
         Run all estimates, based on the default cost and shape models for lattice reduction.
@@ -87,6 +90,7 @@ class Estimate:
         :param add_list: add these ``(name, function)`` pairs to the list of algorithms to estimate.a
         :param jobs: Use multiple threads in parallel.
         :param catch_exceptions: When an estimate fails, just print a warning.
+        :param verbose: If True, prints cost estimates to stdout.
 
         EXAMPLE ::
             >>> from estimator import *
@@ -120,13 +124,15 @@ class Estimate:
             for k, v in res_raw.items()
             if f_name(attack) == k
         }
-        for algorithm in algorithms:
-            if algorithm not in res:
-                continue
-            result = res[algorithm]
-            if result["rop"] == oo:
-                continue
-            print(f"{algorithm:8s} :: {result!r}")
+
+        if verbose:
+            for algorithm in algorithms:
+                if algorithm not in res:
+                    continue
+                result = res[algorithm]
+                if result["rop"] == oo:
+                    continue
+                print(f"{algorithm:8s} :: {result!r}")
 
         return res
 


### PR DESCRIPTION
Adding a `verbose` flag to make the Estimate classes optionally silent, useful when calling the estimator programmatically.
Addresses the following feature request: https://github.com/malb/lattice-estimator/issues/147