### PR TITLE
Doctest.sh

### DIFF
--- a/doctest.sh
+++ b/doctest.sh
@@ -4,7 +4,7 @@
 ###############################################################################
 if [ "x$SAGE_ROOT" == "x" ]
 then
-    SAGE_ROOT=$(sage -c "import os; print(os.environ['SAGE_ROOT'])")
+    SAGE_ROOT=$(sage -c "import os; var = 'SAGE_ROOT' if 'SAGE_ROOT' in os.environ else 'SAGE_VENV'; print(os.environ[var])")
     export SAGE_ROOT="$SAGE_ROOT"
     export PATH="$SAGE_ROOT/bin:$SAGE_ROOT/src/bin:$PATH"
     export SAGE_LOCAL="$SAGE_ROOT/local"

--- a/fix-doctest.sh
+++ b/fix-doctest.sh
@@ -7,7 +7,7 @@
 ###############################################################################
 if [ "x$SAGE_ROOT" == "x" ]
 then
-    SAGE_ROOT=$(sage -c "import os; print(os.environ['SAGE_ROOT'])")
+    SAGE_ROOT=$(sage -c "import os; var = 'SAGE_ROOT' if 'SAGE_ROOT' in os.environ else 'SAGE_VENV'; print(os.environ[var])")
     export SAGE_ROOT="$SAGE_ROOT"
     export PATH="$SAGE_ROOT/bin:$SAGE_ROOT/src/bin:$PATH"
     export SAGE_LOCAL="$SAGE_ROOT/local"


### PR DESCRIPTION
In some Conda installs of sage, SAGE_ROOT is missing. Addressing this in {fix-}doctest.sh