### PR TITLE
bug: square tau in primal hybrid

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Usage examples:
     >>> r = LWE.estimate(schemes.Kyber512)
     bkw                  :: rop: ≈2^178.8, m: ≈2^166.8, mem: ≈2^167.8, b: 14, t1: 0, t2: 16, ℓ: 13, #cod: 448, #top: 0, #test: 64, tag: coded-bkw
     usvp                 :: rop: ≈2^143.8, red: ≈2^143.8, δ: 1.003941, β: 406, d: 998, tag: usvp
-    bdd                  :: rop: ≈2^140.2, red: ≈2^139.4, svp: ≈2^139.0, β: 390, η: 421, d: 1007, tag: bdd
+    bdd                  :: rop: ≈2^140.2, red: ≈2^139.1, svp: ≈2^139.3, β: 389, η: 422, d: 1005, tag: bdd
     dual                 :: rop: ≈2^149.9, mem: ≈2^97.1, m: 512, β: 424, d: 1024, ↻: 1, tag: dual
     dual_hybrid          :: rop: ≈2^139.7, red: ≈2^139.5, guess: ≈2^135.9, β: 387, p: 5, ζ: 0, t: 50, β': 391, N: ≈2^81.1, m: 512
 

--- a/docs/schemes/hes.rst
+++ b/docs/schemes/hes.rst
@@ -8,7 +8,7 @@ Homomorphic Encryption Parameters
     >>> HESv111024128error
     LWEParameters(n=1024, q=134217728, Xs=D(σ=3.00), Xe=D(σ=3.00), m=1024, tag='HESv11error')
     >>> LWE.primal_bdd(HESv111024128error)
-    rop: ≈2^136.7, red: ≈2^136.4, svp: ≈2^134.3, β: 374, η: 404, d: 2047, tag: bdd
+    rop: ≈2^136.7, red: ≈2^136.4, svp: ≈2^134.3, β: 374, η: 404, d: 2044, tag: bdd
 
 ::
 

--- a/docs/schemes/nist-pqc-round-3.rst
+++ b/docs/schemes/nist-pqc-round-3.rst
@@ -9,7 +9,7 @@ NIST PQC Round 3 Finalists
     >>> schemes.Kyber512
     LWEParameters(n=512, q=3329, Xs=D(σ=1.22), Xe=D(σ=1.22), m=512, tag='Kyber 512')
     >>> LWE.primal_bdd(schemes.Kyber512)
-    rop: ≈2^140.2, red: ≈2^139.4, svp: ≈2^139.0, β: 390, η: 421, d: 1007, tag: bdd
+    rop: ≈2^140.2, red: ≈2^139.1, svp: ≈2^139.3, β: 389, η: 422, d: 1005, tag: bdd
 
 ::
 
@@ -35,7 +35,7 @@ NIST PQC Round 3 Finalists
     >>> schemes.LightSaber
     LWEParameters(n=512, q=8192, Xs=D(σ=1.58), Xe=D(σ=2.29, μ=-0.50), m=512, tag='LightSaber')
     >>> LWE.primal_bdd(schemes.LightSaber)
-    rop: ≈2^140.0, red: ≈2^139.4, svp: ≈2^138.5, β: 390, η: 419, d: 1023, tag: bdd
+    rop: ≈2^139.9, red: ≈2^138.9, svp: ≈2^139.0, β: 388, η: 421, d: 1021, tag: bdd
 
 ::
 
@@ -43,7 +43,7 @@ NIST PQC Round 3 Finalists
     >>> schemes.Saber
     LWEParameters(n=768, q=8192, Xs=D(σ=1.41), Xe=D(σ=2.29, μ=-0.50), m=768, tag='Saber')
     >>> LWE.primal_bdd(schemes.Saber)
-    rop: ≈2^208.1, red: ≈2^206.9, svp: ≈2^207.3, β: 631, η: 666, d: 1475, tag: bdd
+    rop: ≈2^208.1, red: ≈2^206.9, svp: ≈2^207.3, β: 631, η: 666, d: 1471, tag: bdd
 
 ::
 
@@ -51,7 +51,7 @@ NIST PQC Round 3 Finalists
     >>> schemes.FireSaber
     LWEParameters(n=1024, q=8192, Xs=D(σ=1.22), Xe=D(σ=2.29, μ=-0.50), m=1024, tag='FireSaber')
     >>> LWE.primal_bdd(schemes.FireSaber)
-    rop: ≈2^275.8, red: ≈2^274.9, svp: ≈2^274.7, β: 873, η: 907, d: 1891, tag: bdd
+    rop: ≈2^275.8, red: ≈2^274.9, svp: ≈2^274.7, β: 873, η: 907, d: 1888, tag: bdd
 
 
 `NTRU <https://ntru.org/f/ntru-20190330.pdf>`__
@@ -62,7 +62,7 @@ NIST PQC Round 3 Finalists
     >>> schemes.NTRUHPS2048509Enc
     NTRUParameters(n=508, q=2048, Xs=D(σ=0.82), Xe=T(p=127, m=127, n=508), m=508, tag='NTRUHPS2048509Enc', ntru_type='matrix')
     >>> NTRU.primal_bdd(schemes.NTRUHPS2048509Enc)
-    rop: ≈2^131.1, red: ≈2^130.1, svp: ≈2^130.1, β: 357, η: 389, d: 913, tag: bdd
+    rop: ≈2^131.1, red: ≈2^130.1, svp: ≈2^130.1, β: 357, η: 389, d: 914, tag: bdd
 
 ::
 
@@ -70,7 +70,7 @@ NIST PQC Round 3 Finalists
     >>> schemes.NTRUHPS2048677Enc
     NTRUParameters(n=676, q=2048, Xs=D(σ=0.82), Xe=T(p=127, m=127, n=676), m=676, tag='NTRUHPS2048677Enc', ntru_type='matrix')
     >>> NTRU.primal_bdd(schemes.NTRUHPS2048677Enc)
-    rop: ≈2^170.7, red: ≈2^169.5, svp: ≈2^169.9, β: 498, η: 532, d: 1176, tag: bdd
+    rop: ≈2^170.7, red: ≈2^169.6, svp: ≈2^169.9, β: 498, η: 532, d: 1177, tag: bdd
 
 ::
 
@@ -78,7 +78,7 @@ NIST PQC Round 3 Finalists
     >>> schemes.NTRUHPS4096821Enc
     NTRUParameters(n=820, q=4096, Xs=D(σ=0.82), Xe=T(p=255, m=255, n=820), m=820, tag='NTRUHPS4096821Enc', ntru_type='matrix')
     >>> NTRU.primal_bdd(schemes.NTRUHPS4096821Enc)
-    rop: ≈2^199.6, red: ≈2^198.6, svp: ≈2^198.6, β: 601, η: 635, d: 1480, tag: bdd
+    rop: ≈2^199.6, red: ≈2^198.6, svp: ≈2^198.6, β: 601, η: 635, d: 1482, tag: bdd
 
 ::
 

--- a/estimator/lwe.py
+++ b/estimator/lwe.py
@@ -119,7 +119,7 @@ class Estimate:
             >>> _ = LWE.estimate(schemes.Kyber512)
             bkw                  :: rop: ≈2^178.8, m: ≈2^166.8, mem: ≈2^167.8, b: 14, t1: 0, t2: 16, ℓ: 13, #cod: 448...
             usvp                 :: rop: ≈2^143.8, red: ≈2^143.8, δ: 1.003941, β: 406, d: 998, tag: usvp
-            bdd                  :: rop: ≈2^140.2, red: ≈2^139.4, svp: ≈2^139.0, β: 390, η: 421, d: 1007, tag: bdd
+            bdd                  :: rop: ≈2^140.2, red: ≈2^139.1, svp: ≈2^139.3, β: 389, η: 422, d: 1005, tag: bdd
             dual                 :: rop: ≈2^149.9, mem: ≈2^97.1, m: 512, β: 424, d: 1024, ↻: 1, tag: dual
             dual_hybrid          :: rop: ≈2^139.7, red: ≈2^139.5, guess: ≈2^135.9, β: 387, p: 5, ζ: 0, t: 50, β': 391...
 

--- a/estimator/lwe_primal.py
+++ b/estimator/lwe_primal.py
@@ -318,7 +318,7 @@ class PrimalHybrid:
                 log_vol = sum(r)
             else:
                 n = len(list(r)) + 1
-                log_vol = sum(r) + log(tau)
+                log_vol = sum(r) + 2 * log(tau)
             log_gh = 1.0 / n * (log_vol - 2 * ball_log_vol(n))
             return log_gh
 
@@ -610,13 +610,13 @@ class PrimalHybrid:
             >>> from estimator import *
             >>> params = schemes.Kyber512.updated(Xs=ND.SparseTernary(16))
             >>> LWE.primal_hybrid(params, mitm=False, babai=False)
-            rop: ≈2^89.4, red: ≈2^88.6, svp: ≈2^88.1, β: 104, η: 18, ζ: 323, |S|: ≈2^39.7, d: 355, prob: ≈2^-27.3, ↻...
+            rop: ≈2^89.3, red: ≈2^88.8, svp: ≈2^87.7, β: 106, η: 18, ζ: 321, |S|: ≈2^39.7, d: 360, prob: ≈2^-26.9, ↻...
 
             >>> LWE.primal_hybrid(params, mitm=False, babai=True)
             rop: ≈2^88.4, red: ≈2^87.8, svp: ≈2^86.9, β: 98, η: 2, ζ: 321, |S|: ≈2^39.7, d: 347, prob: ≈2^-28.1, ↻...
 
             >>> LWE.primal_hybrid(params, mitm=True, babai=False)
-            rop: ≈2^73.4, red: ≈2^72.5, svp: ≈2^72.3, β: 109, η: 16, ζ: 320, |S|: ≈2^82.8, d: 366, prob: 0.001, ↻...
+            rop: ≈2^73.4, red: ≈2^72.5, svp: ≈2^72.3, β: 109, η: 15, ζ: 320, |S|: ≈2^82.8, d: 366, prob: 0.001, ↻...
 
             >>> LWE.primal_hybrid(params, mitm=True, babai=True)
             rop: ≈2^85.5, red: ≈2^84.5, svp: ≈2^84.5, β: 105, η: 2, ζ: 364, |S|: ≈2^85.0, d: 316, prob: ≈2^-23.2, ↻...
@@ -627,15 +627,15 @@ class PrimalHybrid:
 
             >>> params = LWE.Parameters(2**10, 2**100, ND.DiscreteGaussian(3.19), ND.DiscreteGaussian(3.19))
             >>> LWE.primal_bdd(params)
-            rop: ≈2^43.6, red: ≈2^43.6, svp: ≈2^34.3, β: 40, η: 43, d: 1465, tag: bdd
+            rop: ≈2^43.6, red: ≈2^43.6, svp: ≈2^21.9, β: 40, η: 2, d: 1514, tag: bdd
 
         We also test a LWE instance with a large error (coming from issue #106)::
 
             >>> LWE.primal_bdd(LWE.Parameters(n=256, q=12289, Xs=ND.UniformMod(2), Xe=ND.UniformMod(1024)))
-            rop: ≈2^115.7, red: ≈2^41.3, svp: ≈2^115.7, β: 40, η: 337, d: 337, tag: bdd
+            rop: ≈2^115.4, red: ≈2^41.3, svp: ≈2^115.4, β: 40, η: 336, d: 336, tag: bdd
 
             >>> LWE.primal_bdd(LWE.Parameters(n=700, q=2**64, Xs=ND.UniformMod(2), Xe=ND.UniformMod(2**59)))
-            rop: ≈2^261.5, red: ≈2^42.8, svp: ≈2^261.5, β: 40, η: 860, d: 860, tag: bdd
+            rop: ≈2^259.8, red: ≈2^42.8, svp: ≈2^259.8, β: 40, η: 854, d: 854, tag: bdd
 
 
         """


### PR DESCRIPTION
Fixing bug in https://github.com/malb/lattice-estimator/pull/164 : simulator outputs squared norms, so tau should be squared as well.