### PR TITLE
primal_hybrid refactor in GSA case

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,7 @@
 [flake8]
 max-line-length = 120
 black-config = pyproject.toml
-max-complexity = 16
+max-complexity = 17
 extend-ignore =
     # See https://github.com/PyCQA/pycodestyle/issues/373
     E203,E22,E241

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,5 +6,5 @@ addopts = "--ignore=docs/conf.py --doctest-modules --doctest-glob=\"*.rst\" --nb
 
 [tool.flake8]
 max-line-length = 120
-max-complexity = 16
+max-complexity = 17
 extend-ignore = "E203,E22,E241"


### PR DESCRIPTION
Assuming the GSA, the volume of the projected lattice can be calculated from the total volume and root hermite factor only: it is not necessary to simulate BKZ and repeatedly calculate the projected volume with sum(r[i:]). I've added a new function `svp_dimension_gsa` which achieves this.

For normal size parameters, this doesn't make a difference. However, for HE size sparse parameters this is helpful; looking at this [paper from crypto this year](https://eprint.iacr.org/2024/1623.pdf), the parameters (logn, logq, h, sigma_e) = (17, 3104, 192, 3.19) were calculated using linear interpolation (?), I assume because the precision of math.log isn't high enough to run primal_hybrid on these parameters. I was getting a math domain error. With this pull request, the domain error is gone, and I get the same output as when I replace the math.log with sage.all.log, but much faster.

Additionally, for the parameters (logn, logq, h, sigma_e) = (15, 767, 192, 3.19) from the same paper, I run primal_hybrid in ~107s, vs ~160s on main.

As I'm adding an extra if-else, I had to increase the complexity limit 16 -> 17. I also did some additional tidying.