### PR TITLE
Fix memory bug in primal hybrid with babai lifting

### DIFF
--- a/estimator/prob.py
+++ b/estimator/prob.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from sage.all import binomial, ZZ, log, ceil, RealField, oo, exp, pi
+from sage.all import binomial, ZZ, log, ceil, RealField, oo, exp, RDF
 from sage.all import RealDistribution, RR, sqrt, prod, erf
 from .conf import max_n_cache
 
@@ -94,7 +94,9 @@ def mitm_babai_probability(r, stddev, fast=False):
     # Note: `r` contains *square norms*, so convert to non-square norms.
     # Follow the proof of Lemma 4.2 [WAHC:SonChe19]_, because that one uses standard deviation.
     xs = [sqrt(.5 * ri) / stddev for ri in r]
-    p = prod(RR(erf(x) - (1 - exp(-x**2)) / (x * sqrt(pi))) for x in xs)
+    # Using RDF.pi() to prevent memory leakage:
+    # see https://ask.sagemath.org/question/45863/memory-usage-strictly-increasing-on-sage-interactive-shell/
+    p = prod(RR(erf(x) - (1 - exp(-x**2)) / (x * sqrt(RDF.pi()))) for x in xs)
     assert 0.0 <= p <= 1.0
     return p
 
@@ -191,5 +193,7 @@ def amplify_sigma(target_advantage, sigma, q):
     if sigma > 16 * q:
         return oo
 
-    advantage = float(exp(-float(pi) * (float(sigma / q) ** 2)))
+    # Using RDF.pi() to prevent memory leakage:
+    # see https://ask.sagemath.org/question/45863/memory-usage-strictly-increasing-on-sage-interactive-shell/
+    advantage = float(exp(-float(RDF.pi()) * (float(sigma / q) ** 2)))
     return amplify(target_advantage, advantage, majority=True)


### PR DESCRIPTION
Fixing https://github.com/malb/lattice-estimator/issues/172

Judging from this [historic issue](https://ask.sagemath.org/question/45863/memory-usage-strictly-increasing-on-sage-interactive-shell/), this memory leak is not from any calculation, but from the way `pi` is called.

As suggested in the response to this issue, I have changed to `RDF.pi()`, and found this helped a lot: with the same set up as in the issue, and get for the first few iterations:

```
change in memory = 20.37 MiB
malloc:
/lattice_estimator/estimator/prob.py:9: size=1563 KiB, count=20001, average=80 B
/lattice_estimator/estimator/prob.py:7: size=1116 KiB, count=19746, average=58 B
<frozen importlib._bootstrap_external>:647: size=534 KiB, count=3859, average=142 B
/miniforge3/envs/sage/lib/python3.9/site-packages/sage/categories/sets_cat.py:1011: size=157 KiB, count=1166, average=138 B
/miniforge3/envs/sage/lib/python3.9/site-packages/sage/structure/dynamic_class.py:463: size=94.7 KiB, count=365, average=266 B
/miniforge3/envs/sage/lib/python3.9/weakref.py:349: size=68.6 KiB, count=878, average=80 B
/lattice_estimator/estimator/reduction.py:77: size=46.9 KiB, count=647, average=74 B
/miniforge3/envs/sage/lib/python3.9/site-packages/sage/rings/qqbar.py:6701: size=22.3 KiB, count=292, average=78 B
/miniforge3/envs/sage/lib/python3.9/dataclasses.py:400: size=19.3 KiB, count=200, average=99 B
/miniforge3/envs/sage/lib/python3.9/site-packages/sage/symbolic/constants.py:586: size=17.0 KiB, count=217, average=80 B

change in memory = 3.13 MiB
malloc:
/lattice_estimator/estimator/prob.py:9: size=1563 KiB, count=20001, average=80 B
/lattice_estimator/estimator/prob.py:7: size=1116 KiB, count=19746, average=58 B
<frozen importlib._bootstrap_external>:647: size=534 KiB, count=3859, average=142 B
/miniforge3/envs/sage/lib/python3.9/site-packages/sage/categories/sets_cat.py:1011: size=160 KiB, count=1192, average=138 B
/miniforge3/envs/sage/lib/python3.9/site-packages/sage/structure/dynamic_class.py:463: size=96.5 KiB, count=373, average=265 B
/miniforge3/envs/sage/lib/python3.9/weakref.py:349: size=75.4 KiB, count=965, average=80 B
/lattice_estimator/estimator/reduction.py:77: size=56.8 KiB, count=773, average=75 B
/lattice_estimator/estimator/lwe_primal.py:491: size=29.4 KiB, count=376, average=80 B
/miniforge3/envs/sage/lib/python3.9/site-packages/sage/rings/qqbar.py:6701: size=22.3 KiB, count=292, average=78 B
/miniforge3/envs/sage/lib/python3.9/site-packages/sage/symbolic/constants.py:586: size=20.2 KiB, count=259, average=80 B

change in memory = -1.55 MiB
malloc:
/lattice_estimator/estimator/prob.py:9: size=1563 KiB, count=20001, average=80 B
/lattice_estimator/estimator/prob.py:7: size=1116 KiB, count=19746, average=58 B
<frozen importlib._bootstrap_external>:647: size=534 KiB, count=3859, average=142 B
/miniforge3/envs/sage/lib/python3.9/site-packages/sage/categories/sets_cat.py:1011: size=163 KiB, count=1220, average=137 B
/miniforge3/envs/sage/lib/python3.9/site-packages/sage/structure/dynamic_class.py:463: size=96.5 KiB, count=373, average=265 B
/miniforge3/envs/sage/lib/python3.9/weakref.py:349: size=75.4 KiB, count=965, average=80 B
/lattice_estimator/estimator/reduction.py:77: size=66.6 KiB, count=899, average=76 B
/lattice_estimator/estimator/lwe_primal.py:491: size=40.5 KiB, count=518, average=80 B
/miniforge3/envs/sage/lib/python3.9/site-packages/sage/symbolic/constants.py:586: size=23.5 KiB, count=301, average=80 B
/lattice_estimator/estimator/reduction.py:740: size=23.0 KiB, count=517, average=46 B
```

which looks like just background memory noise, and much smaller than before. I have used RDF and not RR because of [this comment](https://github.com/sagemath/sage/issues/27536#issuecomment-1418027297).

NB: this issue was apparently fixed in Sage a few months ago, see [here](https://github.com/sagemath/sage/commit/c12fe5dc824f9ac31498747fe602690d8defad8b), so updating would also probably fix the issue.