### PR TITLE
Remove usage of 'is' operator for boolean comparison

### DIFF
--- a/estimator/cost.py
+++ b/estimator/cost.py
@@ -85,14 +85,14 @@ class Cost(UserDict):
                     vv = "%7s" % ("≈2^%.1f" % log(v, 2))
             except TypeError:  # strings and such
                 vv = "%8s" % v
-            if compact is True:
+            if compact:
                 kk = kk.strip()
                 vv = vv.strip()
             return f"{kk}: {vv}"
 
         # we store the problem instance in a cost object for reference
         s = [value_str(k, v) for k, v in self.items() if k != "problem"]
-        delimiter = "\n" if newline is True else ", "
+        delimiter = "\n" if newline else ", "
         return delimiter.join(s)
 
     def reorder(self, *args):

--- a/estimator/cost.py
+++ b/estimator/cost.py
@@ -190,7 +190,7 @@ class Cost(UserDict):
         return Cost(**cost)
 
     def __bool__(self):
-        return self.get("rop", oo) < oo
+        return bool(self.get("rop", oo) < oo)
 
     def __add__(self, other):
         return self.combine(self, other)

--- a/estimator/lwe_dual.py
+++ b/estimator/lwe_dual.py
@@ -289,7 +289,7 @@ class DualHybrid:
             log_level=log_level,
         )
 
-        if fft is True:
+        if fft:
 
             def f(beta):
                 with local_minimum(0, params.n - zeta) as it:
@@ -770,7 +770,7 @@ def dual_hybrid(
     - ``t``: Number of secrets to guess mod 2 (only if ``fft`` is ``True``)
     """
 
-    if mitm_optimization is True:
+    if mitm_optimization:
         mitm_optimization = mitm_opt_default
 
     if mitm_optimization:

--- a/estimator/lwe_guess.py
+++ b/estimator/lwe_guess.py
@@ -182,7 +182,7 @@ class ExhaustiveSearch:
             # so we approximate the cost with oo
             return Cost(rop=oo, mem=oo, m=1)
 
-        if quantum is True:
+        if quantum:
             size = size.sqrt()
 
         # set m according to [ia.cr/2020/515]

--- a/estimator/reduction.py
+++ b/estimator/reduction.py
@@ -994,7 +994,7 @@ def cost(cost_model, beta, d, B=None, predicate=True, **kwds):
     delta_ = ReductionCost.delta(beta)
     cost = Cost(rop=cost, red=cost, delta=delta_, beta=beta, d=d, **kwds)
     cost.register_impermanent(rop=True, red=True, delta=False, beta=False, d=False)
-    if predicate is False:
+    if not predicate:
         cost["red"] = oo
         cost["rop"] = oo
     return cost

--- a/estimator/util.py
+++ b/estimator/util.py
@@ -177,7 +177,7 @@ class local_minimum_base:
             self._best = Bounds(self._last_x, res)
 
         # We found something better
-        if res is not False and self._smallerf(res, self._best.high):
+        if res and self._smallerf(res, self._best.high):
             # store it
             self._best = Bounds(self._last_x, res)
 
@@ -347,7 +347,7 @@ class early_abort_range:
             self._best = Bounds(self._last_x, res)
             return
 
-        if res is False:
+        if not res:
             self._next_x = None
         elif self._smallerf(res, self._best.high):
             self._best = Bounds(self._last_x, res)

--- a/param_sweep.py
+++ b/param_sweep.py
@@ -295,14 +295,14 @@ class ParameterSweep:
         assert num_proc >= 1, "need at least one process to execute"
 
         pickle_filename = f"{file_name}.pickle"
-        if load_pickle is True:
+        if load_pickle:
             with open(pickle_filename, "rb") as f:
                 result_dict = pickle.load(f)
         else:
             result_dict = ParameterSweep.parameter_sweep(
                 n, q, e, s, m, Xe, e_log, Xs, s_log, tag, f, num_proc, log_level
             )
-            if make_pickle is True:
+            if make_pickle:
                 # Pickle the intermediate computation results
                 with open(pickle_filename, "wb") as f:
                     pickle.dump(result_dict, f)


### PR DESCRIPTION
The ['is' operator](https://docs.python.org/3/reference/expressions.html#is-not) is used in some `if` statements in the code to test equalities with boolean values (`condition is True`, `condition is not True`, ...). This is too restrictive and can lead to weird behaviors (see example below).
This PR proposes to replace all occurrences of `if condition is True`, `if condition is False`, `if condition is not True`, `if condition is not False` by the more general [boolean statements](https://docs.python.org/3/reference/expressions.html#boolean-operations) `if condition` and `if not condition`, which perform boolean conversion contrary to the `is` operator.

## Example

Consider the following code:

```py
from estimator import *

RingDegree = 256
MatrixDim = 3
SumSize = 2
SumNumber = 2**5
Modulus=11017217
MaskingLevel = 8
variance = (2**SumSize)*sqrt((SumNumber-MaskingLevel+1)/6) #20*sqrt(1/6)
n = RingDegree * MatrixDim


for var in (variance, float(variance)):
  print(f"#### {var=}")
  nd = ND.NoiseDistribution(None, 0, var)
  params = LWE.Parameters(n=n, q=Modulus, Xs=nd, Xe=nd,m=n)
  LWE.estimate(params)
```

In the first iterator the variance is a symbolic expression from SageMath, in the second iteration the variance is the corresponding float value. The two estimates return very different values for uvsp: $2^{43.0}$ versus $2^{141.4}$.
The difference is only due to the [condition line 997 of `reduction.py`](https://github.com/malb/lattice-estimator/blob/352ddaf4a288a0543f5d9eb588d2f89c7acec463/estimator/reduction.py#L997):
```py
if predicate is False:
  ...
```
The function `cost` is called by `cost_gsa` with `predicate = lhs <= rhs`. By using the `is` operator, conversion to boolean are prevented. So when using symbolic expression from SageMath, `predicate` is not a boolean but a symbolic expression which is convertible to a boolean with a meaningful truth value but the conversion is prevented by the usage of the `is` operator. By replacing the condition by
```py
if not predicate:
  ...
```
fixed the problem.
