### PR TITLE
(schemes): add TFHE-rs parameters from v1.6

### DIFF
--- a/estimator/schemes.py
+++ b/estimator/schemes.py
@@ -1,5 +1,5 @@
 from sage.all import oo
-from .nd import stddevf, Binary, CenteredBinomial, DiscreteGaussian, SparseTernary, UniformMod
+from .nd import stddevf, Binary, CenteredBinomial, DiscreteGaussian, SparseTernary, UniformMod, TUniform
 from .lwe_parameters import LWEParameters
 from .ntru_parameters import NTRUParameters
 from .sis_parameters import SISParameters
@@ -333,6 +333,25 @@ Concrete_TFHE512 = LWEParameters(
     Xs=Binary,
     Xe=DiscreteGaussian(stddev=2 ** (-24.8) * 2**32),
     tag="Concrete_TFHE512",
+)
+
+# TFHE-rs Parameters
+# https://github.com/zama-ai/tfhe-rs/blob/main/tfhe/src/shortint/parameters/v1_4/classic/tuniform/p_fail_2_minus_128/ks_pbs.rs#L29
+# - Key-Switching key (LWE)
+TFHErs_LWE = LWEParameters(
+    n=918,
+    q=2**64,
+    Xs=Binary,
+    Xe=TUniform(45),
+    tag="TFHErs_LWE",
+)
+# - Bootstrapping key (Ring-LWE)
+TFHErs_RLWE = LWEParameters(
+    n=2048,
+    q=2**64,
+    Xs=Binary,
+    Xe=TUniform(17),
+    tag="TFHErs_RLWE",
 )
 
 # https://eprint.iacr.org/2018/421.pdf


### PR DESCRIPTION
Adding TFHE-rs parameters to `schemes.py`. These are current parameters used in v1.6, and can be found here: 

https://github.com/zama-ai/tfhe-rs/blob/main/tfhe/src/shortint/parameters/v1_4/classic/tuniform/p_fail_2_minus_128/ks_pbs.rs#L29