### PR TITLE
HE Parameters and Tests

### DIFF
--- a/docs/schemes/hes.rst
+++ b/docs/schemes/hes.rst
@@ -1,29 +1,38 @@
 Homomorphic Encryption Parameters
 =================================
+Import a selection of parameters used in applications of Homomorphic Encryption, and estimate the best performing attack against each.
 
 ::
 
     >>> from estimator import *
-    >>> from estimator.schemes import HESv111024128error
-    >>> HESv111024128error
-    LWEParameters(n=1024, q=134217728, Xs=D(σ=3.00), Xe=D(σ=3.00), m=1024, tag='HESv11error')
-    >>> LWE.primal_bdd(HESv111024128error)
-    rop: ≈2^136.7, red: ≈2^136.4, svp: ≈2^134.3, β: 374, η: 404, d: 2044, tag: bdd
+    >>> from estimator.schemes import TFHErs_LWE
+    >>> LWE.dual_hybrid(TFHErs_LWE)
+    rop: ≈2^134.9, red: ≈2^134.9, guess: ≈2^128.0, β: 366, p: 2, ζ: 0, t: 110, β': 375, N: ≈2^77.1, m: 918
 
 ::
 
     >>> from estimator import *
-    >>> from estimator.schemes import HESv111024128ternary
-    >>> HESv111024128ternary
-    LWEParameters(n=1024, q=134217728, Xs=D(σ=0.82), Xe=D(σ=3.00), m=1024, tag='HESv11ternary')
-    >>> LWE.primal_hybrid(HESv111024128ternary)
-    rop: ≈2^182.8, red: ≈2^180.4, svp: ≈2^182.5, β: 345, η: 2, ζ: 137, |S|: ≈2^217.1, d: 1875, prob: ≈2^-50.0, ↻: ≈2^52.2, tag: hybrid
-   
+    >>> from estimator.schemes import TFHErs_RLWE
+    >>> LWE.dual_hybrid(TFHErs_RLWE)
+    rop: ≈2^134.8, red: ≈2^134.7, guess: ≈2^128.0, β: 360, p: 2, ζ: 0, t: 110, β': 375, N: ≈2^77.3, m: ≈2^11.0
+
 ::
 
     >>> from estimator import *
-    >>> from estimator.schemes import SEAL22_8192
-    >>> SEAL22_8192
-    LWEParameters(n=8192, q=107839786668602559178668060348078522694548577690162289924414373888001, Xs=D(σ=0.82), Xe=D(σ=3.19), m=+Infinity, tag='SEAL22_8192')
-    >>> LWE.dual_hybrid(SEAL22_8192)
-    rop: ≈2^121.8, red: ≈2^121.8, guess: ≈2^101.7, β: 306, p: 3, ζ: 10, t: 40, β': 331, N: ≈2^68.1, m: ≈2^13.0
+    >>> from estimator.schemes import HESv2_8192_128_ternary
+    >>> LWE.primal_bdd(HESv2_8192_128_ternary)
+    rop: ≈2^128.3, red: ≈2^128.0, svp: ≈2^125.7, β: 332, η: 373, d: 16216, tag: bdd
+
+::
+
+    >>> from estimator import *
+    >>> from estimator.schemes import HESv2_32768_128_ternary
+    >>> LWE.primal_bdd(HESv2_32768_128_ternary)
+    rop: ≈2^128.0, red: ≈2^128.0, svp: ≈2^118.7, β: 325, η: 348, d: 63105, tag: bdd
+
+::
+
+    >>> from estimator import *
+    >>> from estimator.schemes import HESv2_131072_128_ternary
+    >>> LWE.primal_bdd(HESv2_131072_128_ternary)
+    rop: ≈2^127.9, red: ≈2^127.9, svp: ≈2^118.7, β: 317, η: 348, d: 260026, tag: bdd

--- a/estimator/schemes.py
+++ b/estimator/schemes.py
@@ -587,6 +587,7 @@ TFHErs_LWE = LWEParameters(
     Xe=TUniform(45),
     tag="TFHErs_LWE",
 )
+
 # Bootstrapping key (Ring-LWE)
 TFHErs_RLWE = LWEParameters(
     n=2048,
@@ -604,6 +605,7 @@ HESv2_8192_128_ternary = LWEParameters(
     Xs=Ternary,
     tag="HESv2_8192_128_ternary"
 )
+
 HESv2_16384_128_ternary = LWEParameters(
     n=16384,
     q=2 ** 430,

--- a/estimator/schemes.py
+++ b/estimator/schemes.py
@@ -1,5 +1,5 @@
 from sage.all import oo
-from .nd import stddevf, Binary, CenteredBinomial, DiscreteGaussian, SparseTernary, UniformMod
+from .nd import stddevf, Binary, CenteredBinomial, DiscreteGaussian, SparseTernary, UniformMod, Ternary, TUniform
 from .lwe_parameters import LWEParameters
 from .ntru_parameters import NTRUParameters
 from .sis_parameters import SISParameters
@@ -575,4 +575,63 @@ CHHS_4096_82 = LWEParameters(
     Xs=SparseTernary(32),
     Xe=DiscreteGaussian(stddev=stddevf(8)),
     tag="CHHS_4096_82",
+)
+
+# TFHE-rs Parameters
+# https://github.com/zama-ai/tfhe-rs/blob/main/tfhe/src/shortint/parameters/v1_4/classic/tuniform/p_fail_2_minus_128/ks_pbs.rs#L29
+# Key-Switching key (LWE)
+TFHErs_LWE = LWEParameters(
+    n=918,
+    q=2**64,
+    Xs=Binary,
+    Xe=TUniform(45),
+    tag="TFHErs_LWE",
+)
+# Bootstrapping key (Ring-LWE)
+TFHErs_RLWE = LWEParameters(
+    n=2048,
+    q=2**64,
+    Xs=Binary,
+    Xe=TUniform(17),
+    tag="TFHErs_RLWE",
+)
+
+# Selected ternary parameters from v2 of the HE Standard, see https://eprint.iacr.org/2024/463, Table 5.2
+HESv2_8192_128_ternary = LWEParameters(
+    n=8192,
+    q=2 ** 214,
+    Xe=DiscreteGaussian(3.19),
+    Xs=Ternary,
+    tag="HESv2_8192_128_ternary"
+)
+HESv2_16384_128_ternary = LWEParameters(
+    n=16384,
+    q=2 ** 430,
+    Xe=DiscreteGaussian(3.19),
+    Xs=Ternary,
+    tag="HESv2_16384_128_ternary"
+)
+
+HESv2_32768_128_ternary = LWEParameters(
+    n=32768,
+    q=2 ** 868,
+    Xe=DiscreteGaussian(3.19),
+    Xs=Ternary,
+    tag="HESv2_32768_128_ternary"
+)
+
+HESv2_65536_128_ternary = LWEParameters(
+    n=65536,
+    q=2 ** 1747,
+    Xe=DiscreteGaussian(3.19),
+    Xs=Ternary,
+    tag="HESv2_65536_128_ternary"
+)
+
+HESv2_131072_128_ternary = LWEParameters(
+    n=131072,
+    q=2 ** 3523,
+    Xe=DiscreteGaussian(3.19),
+    Xs=Ternary,
+    tag="HESv2_131072_128_ternary"
 )


### PR DESCRIPTION
Add parameters from the most recent HE standard and tfhe-rs library. Additionally put some tests for a selection of these parameters to `hes.rst`, replacing the parameters there, which are now outdated.

On main, `hes.rst` currently takes about 1 minute on my machine, whereas this new `hes.rst` takes 2min30s. If this is unacceptable overhead, I can drop the largest parameter set (n=2^17). 

replaces #199 

Coauthored by @bencrts 