### PR TITLE
Fix Binary Search Off-by-one

### DIFF
--- a/estimator/util.py
+++ b/estimator/util.py
@@ -93,8 +93,8 @@ class local_minimum_base:
 
         """
 
-        if stop < start:
-            raise ValueError(f"Incorrect bounds {start} > {stop}.")
+        if stop <= start:
+            raise ValueError(f"Incorrect bounds {start} >= {stop}.")
 
         self._suppress_bounds_warning = suppress_bounds_warning
         self._log_level = log_level

--- a/estimator/util.py
+++ b/estimator/util.py
@@ -252,7 +252,7 @@ class local_minimum(local_minimum_base):
         self._precision = precision
         self._orig_bounds = (start, stop)
         start = ceil(start / precision)
-        stop = floor(stop / precision)
+        stop = floor((stop + precision - 1) / precision)
         local_minimum_base.__init__(self, start, stop, smallerf, suppress_bounds_warning, log_level)
 
     def __next__(self):


### PR DESCRIPTION
The binary search in util.py has an off-by-one error. You can see it appear in this issue: https://github.com/malb/lattice-estimator/issues/115.

First, the `local_minimum_base` states that the `stop` value is exclusive, but then it only checks for `stop < start`. However, if the intended range is `[start, stop)`, then `stop = start` is also an invalid (i.e., empty) range. It's because such a range is empty that the bug above appears, since the iterator will not return any values, so it never calls `update`, so many class variables are still set to `None` when `local_minimum` tries to use them. 

The problem seems to occur when `local_minimum` is given a range `start`, `stop`, and `precision` such that `stop < start + precision`. That is, there is only one value that should be checked in the "spaced out" search. However, the `stop` passed to `local_minimum_base` is set to `floor(stop / precision)`, which means e.g. when given (40,41,2), it will send `start=20` and `stop=20` to `local_minimum_base`. 

Since the `stop` passed to `local_minimum` should be exclusive, then the next `stop` should _also_ be exclusive. That is, if x is the maximum integer we want to include in the range we search, we want the value of `stop` sent to `local_minimum_base` to be the smallest integer value such that `x < stop * precision`. 

This should also fix search ranges that do not throw an error: Given (40,45,2), `local_minimum_base` should iterate through [20,21,22]. But it will be given `start=20` and `stop=22` which should only iterate through [20,21].

(Unfortunately I can't figure out how to make pytest work with my installation of sage, so all tests fail both before and after this change).
