### PR TITLE
New pyproject.toml, installable repository

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,24 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "lattice-estimator"
+version = "0.1.0"
+description = "Lattice-based cryptographic parameter estimator"
+readme = "README.rst"
+requires-python = ">=3.9"
+dependencies = []
+
+[tool.uv]
+python-preference = "system"
+
+
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["estimator*"]
+
 [tool.black]
 line-length = 120
 
@@ -8,3 +29,4 @@ addopts = "--ignore=docs/conf.py --doctest-modules --doctest-glob=\"*.rst\" --nb
 max-line-length = 120
 max-complexity = 17
 extend-ignore = "E203,E22,E241"
+


### PR DESCRIPTION
This new pyproject.toml  allows installation of the github repository with pip, using the command "pip install ." 
I have read the issue https://github.com/malb/lattice-estimator/issues/79, regarding the fact it was not possible to install the library on Linux as there is a name collision with another pypi repo.

This new toml file should partially fix this issue, while still needing to download manually the repo from github and running pip install .

PS: This is my first pull request, so apologies if I got something wrong, either in how the PR is set up or in the changes themselves. Happy to fix anything you point out!