### PR TITLE
sis: fix Euclidean cost hangs and large-q overflow

### DIFF
--- a/docs/algorithms/sis-lattice.rst
+++ b/docs/algorithms/sis-lattice.rst
@@ -13,7 +13,9 @@ The simplest (and quickest to estimate) model is solving for the SIS instance wi
 
     SIS.lattice(params)
 
-The exact reduction shape model does not matter when using euclidean norm bounds, as the required block size is calculated directly from the length bound. 
+The exact reduction shape model does not matter when using euclidean norm bounds, as the required block size is calculated directly from the length bound. Passing ``red_shape_model`` to ``SIS.lattice()`` for ``norm=2`` parameters has no effect (a warning is emitted if a non-default simulator is supplied).
+
+When the implied root-Hermite factor ``δ`` falls below ``_delta(2^{16})``, the required BKZ block size exceeds the Chen-model search bracket. The bounded inversion reports this as ``β = +Infinity``; the Euclidean SIS estimator then reports ``rop: inf`` instead of falling back to an unbounded search.
 
 For infinity norm length bounds, we have two separate analyses. Both follow the same basic strategy. We use the worst case euclidean norm bound as a lower bound on the hardness. Then, we analyze the probability of obtaining a short vector where every coordinate meets the infinity norm constraint. When sqrt(m)*length_bound is less than the modulus q, we follow the analysis of the MATZOV report ([MATZOV22]_ P.18). We simulate the cost of generating *many* short vectors and treat each coordinate of the vector as an i.i.d Gaussian random variable with standard deviation equal to the length(s) of these short vectors divided by the square root of the dimension.::
 

--- a/estimator/reduction.py
+++ b/estimator/reduction.py
@@ -10,6 +10,10 @@ from .cost import Cost
 
 
 class ReductionCost:
+    # Upper bracket used by ``_beta_find_root``. If the required β is beyond this
+    # range, beta inversion returns ``oo`` rather than pretending the cap is exact.
+    BETA_SEARCH_MAX = 2**16
+
     @staticmethod
     def _delta(beta):
         """
@@ -127,9 +131,29 @@ class ReductionCost:
                 raise RuntimeError("β < 40")
             return beta
         except (RuntimeError, TypeError):
-            # if something fails, use old beta method
+            if ReductionCost._beta_unbracketed(delta):
+                return oo
             beta = ReductionCost._beta_simple(delta)
             return beta
+
+    @staticmethod
+    def _beta_unbracketed(delta):
+        """
+        Return ``True`` when the root-Hermite factor ``δ`` is below
+        ``_delta(BETA_SEARCH_MAX)``, so the required block size exceeds the
+        ``find_root`` search bracket. Callers use ``oo`` for this out-of-range
+        result rather than a finite β value.
+
+        TESTS::
+
+            >>> from estimator.reduction import ReductionCost, RC
+            >>> ReductionCost._beta_unbracketed(RC.delta(ReductionCost.BETA_SEARCH_MAX))
+            False
+            >>> ReductionCost._beta_unbracketed(RR(1.0000000000453744))
+            True
+
+        """
+        return RR(delta) < ReductionCost._delta(ZZ(ReductionCost.BETA_SEARCH_MAX))
 
     @staticmethod
     def _beta_find_root(delta):
@@ -143,6 +167,9 @@ class ReductionCost:
             >>> from estimator.reduction import ReductionCost, RC
             >>> ReductionCost._beta_find_root(RC.delta(500))
             500
+            >>> from sage.all import oo
+            >>> ReductionCost._beta_find_root(RR(1.0000000000453744)) == oo
+            True
 
         """
         # handle beta < 40 separately
@@ -152,13 +179,18 @@ class ReductionCost:
 
         try:
             beta = find_root(
-                lambda beta: RR(ReductionCost._delta(beta) - delta), 40, 2**16, maxiter=500
+                lambda beta: RR(ReductionCost._delta(beta) - delta),
+                40,
+                ReductionCost.BETA_SEARCH_MAX,
+                maxiter=500,
             )
             beta = ceil(beta - 1e-8)
         except RuntimeError:
             # finding root failed; reasons:
             # 1. maxiter not sufficient
             # 2. no root in given interval
+            if ReductionCost._beta_unbracketed(delta):
+                return oo
             beta = ReductionCost._beta_simple(delta)
         return beta
 

--- a/estimator/sis_lattice.py
+++ b/estimator/sis_lattice.py
@@ -6,6 +6,7 @@ See :ref:`SIS Lattice Attacks` for an introduction what is available.
 
 """
 from functools import partial
+import warnings
 
 from sage.all import oo, sqrt, log, RR, floor, cached_function
 from .reduction import beta as betaf
@@ -53,6 +54,26 @@ class SISLattice:
         log_level=None,
         **kwds,
     ):
+        """
+        Estimate the cost of attacking SIS with a Euclidean length bound.
+
+        TESTS::
+
+            >>> from estimator.sis_lattice import SISLattice
+            >>> from estimator.sis_parameters import SISParameters
+            >>> from estimator.reduction import RC
+            >>> from sage.all import oo
+            >>> q = 2**200
+            >>> params = SISParameters(n=512, q=q, m=1024, length_bound=1000, norm=2, tag="large-q")
+            >>> cost = SISLattice.cost_euclidean(params, d=40, red_cost_model=RC.BDGL16)
+            >>> cost["rop"] == oo and cost["beta"] == 40
+            True
+            >>> params = SISParameters(n=32, q=4294967291, m=128, length_bound=256, norm=2)
+            >>> cost = SISLattice.cost_euclidean(params, red_cost_model=RC.BDGL16)
+            >>> cost["rop"] == oo
+            True
+
+        """
         # Check for triviality
         if params.length_bound >= (params.q - 1) / 2:
             raise ValueError("SIS trivially easy. Please set norm bound < (q-1)/2.")
@@ -62,16 +83,24 @@ class SISLattice:
 
         # First solve for root hermite factor
         delta = SISLattice._solve_for_delta_euclidean(params, d)
-        # Then derive beta from the cost model(s)
-        if delta >= 1 and betaf(delta) <= d:
-            beta = betaf(delta)
+        # Then derive beta from the cost model(s). ``betaf`` returns ``oo`` when
+        # the required block size lies outside the supported search bracket.
+        beta = betaf(delta) if delta >= 1 else oo
+        if beta <= d:
             reduction_possible = True
 
         else:
             beta = d
             reduction_possible = False
 
-        lb = min(RR(sqrt(params.n * log(params.q))), RR(sqrt(d) * params.q ** (params.n / d)))
+        # Compare min(A, B) for A = sqrt(n log q), B = sqrt(d) q^(n/d) in log space
+        # so q^(n/d) is not evaluated when the other branch is smaller.
+        log_A_sq = log(params.n * log(params.q))
+        log_B_sq = log(d) + 2 * (params.n / d) * log(params.q)
+        if log_A_sq <= log_B_sq:
+            lb = RR(sqrt(params.n * log(params.q)))
+        else:
+            lb = RR(sqrt(d) * params.q ** (params.n / d))
         return costf(
             red_cost_model, beta, d, predicate=params.length_bound > lb and reduction_possible
         )
@@ -284,6 +313,10 @@ class SISLattice:
             >>> SIS.lattice(params)
             rop: ≈2^47.0, red: ≈2^47.0, δ: 1.011391, β: 61, d: 276, tag: euclidean
 
+            >>> euclid_params = SIS.Parameters(n=32, q=4294967291, m=128, length_bound=256, norm=2)
+            >>> SIS.lattice(euclid_params, red_cost_model=RC.BDGL16, log_level=0)["rop"] == oo
+            True
+
             >>> SIS.lattice(params.updated(norm=oo, length_bound=16), red_shape_model="lgsa")
             rop: ≈2^61.0, red: ≈2^59.9, sieve: ≈2^60.1, β: 95, η: 126, ζ: 0, d: 2486, prob: 1, ↻: 1, tag: infinity
 
@@ -334,6 +367,12 @@ class SISLattice:
                 cost = f(zeta=zeta)
 
         else:
+            if simulator_normalize(red_shape_model) is not simulator_normalize(red_shape_model_default):
+                warnings.warn(
+                    "red_shape_model is ignored for Euclidean (norm=2) SIS estimates; "
+                    "reduction shape simulators apply only to infinity-norm attacks.",
+                    stacklevel=2,
+                )
             cost = self.cost_euclidean(
                 params=params,
                 red_cost_model=red_cost_model,


### PR DESCRIPTION
TLDR: a few reliability fixes for the SIS estimator as I'm using it for my project

## Summary

- Fix infinite loop when Euclidean SIS estimation needs a BKZ block size outside the Chen-model `find_root` bracket (`δ` near 1): bounded beta inversion now returns `oo` instead of falling through to unbounded `_beta_simple`.
- Fix large-modulus overflow in `cost_euclidean` by comparing the two length-bound branches in log space before evaluating `q^(n/d)`.
- Document that `red_shape_model` is ignored on the Euclidean (`norm=2`) path; warn when a non-default simulator is passed.

## Motivation

General reliability fixes for Euclidean SIS estimation: degenerate instances that previously hung now complete in bounded time, and large-`q` parameter sets no longer overflow during the length-bound predicate.

## Test plan

- [x] `PYTHONIOENCODING=UTF-8 PYTHONPATH=$(pwd) sage -t estimator/reduction.py estimator/sis_lattice.py`
- [ ] `pytest` / CI on PR