### PR TITLE
Add explicit SIS zeta search controls

### DIFF
--- a/docs/algorithms/sis-lattice.rst
+++ b/docs/algorithms/sis-lattice.rst
@@ -34,5 +34,34 @@ Another option is to simulate a rerandomization of the basis, such that the q-ve
 
     SIS.lattice(params.updated(length_bound=70), red_shape_model=Simulator.LGSA)
 
+The Dilithium submission's Core-SVP-style MSIS estimates are reproduced by combining the LGSA
+shape model with the ADPS16 Core-SVP reduction cost model. For example, the built-in Dilithium
+MSIS parameter sets recover the published weak-unforgeability block sizes ``423``, ``638`` and
+``909`` using::
+
+    SIS.lattice(
+        schemes.Dilithium2_MSIS_WkUnf,
+        red_cost_model=RC.ADPS16,
+        red_shape_model="lgsa",
+        zeta=0,
+    )
+
+The default ``SIS.lattice`` cost and shape models are intentionally more general and are not meant
+to be a byte-for-byte reproduction of the Dilithium submission scripts.
+
+For debugging infinity-norm estimates, pass ``diagnostics=True``. The returned cost dictionary then
+includes the selected infinity-norm regime, the branch ratio ``sqrt(d) * length_bound / q``, the
+q-vector and unit-vector cut points used by the Dilithium-style analysis, the number of
+Gaussian-modeled coordinates, the generated short-vector count, and the base-2 log trial
+probability.::
+
+    SIS.lattice(
+        schemes.Dilithium2_MSIS_WkUnf,
+        red_cost_model=RC.ADPS16,
+        red_shape_model="lgsa",
+        zeta=0,
+        diagnostics=True,
+    )
+
 **Note:** Currently, lattice attack estimation is only available for euclidean (``2``) and infinity (``oo``) norms. ``SIS.lattice()`` will return a ``NotImplementedError`` if one of these two norms are not selected.
                         

--- a/docs/algorithms/sis-lattice.rst
+++ b/docs/algorithms/sis-lattice.rst
@@ -52,8 +52,9 @@ to be a byte-for-byte reproduction of the Dilithium submission scripts.
 For debugging infinity-norm estimates, pass ``diagnostics=True``. The returned cost dictionary then
 includes the selected infinity-norm regime, the branch ratio ``sqrt(d) * length_bound / q``, the
 q-vector and unit-vector cut points used by the Dilithium-style analysis, the number of
-Gaussian-modeled coordinates, the generated short-vector count, and the base-2 log trial
-probability.::
+Gaussian-modeled coordinates, the generated short-vector count, the base-2 log Gaussian
+coordinate probability, the base-2 log trial probability, and the capped base-2 log success
+probability used for amplification.::
 
     SIS.lattice(
         schemes.Dilithium2_MSIS_WkUnf,

--- a/docs/algorithms/sis-lattice.rst
+++ b/docs/algorithms/sis-lattice.rst
@@ -63,5 +63,19 @@ probability.::
         diagnostics=True,
     )
 
+By default, infinity-norm estimates optimize over the number of ignored coordinates ``zeta``.
+Passing an integer ``zeta`` evaluates a fixed ignored-coordinate count. Passing
+``zeta_candidates`` evaluates only the provided candidate counts and picks the cheapest result,
+which is useful for reproducible parameter sweeps where a full ``0..m`` search would be too
+expensive.::
+
+    SIS.lattice(
+        schemes.Dilithium2_MSIS_WkUnf,
+        red_cost_model=RC.ADPS16,
+        red_shape_model="lgsa",
+        zeta_candidates=[0, 64, 128],
+        diagnostics=True,
+    )
+
 **Note:** Currently, lattice attack estimation is only available for euclidean (``2``) and infinity (``oo``) norms. ``SIS.lattice()`` will return a ``NotImplementedError`` if one of these two norms are not selected.
                         

--- a/estimator/prob.py
+++ b/estimator/prob.py
@@ -38,7 +38,7 @@ def conditional_chi_squared(d1, d2, lt, l2):
     EXAMPLE::
         >>> from estimator import prob
         >>> prob.conditional_chi_squared(100, 5, 105, 1)
-        0.6358492948586715
+        0.63584929485867...
 
         >>> prob.conditional_chi_squared(100, 5, 105, 5)
         0.5764336909205551
@@ -50,7 +50,7 @@ def conditional_chi_squared(d1, d2, lt, l2):
         1.170759720628...e-06
 
         >>> prob.conditional_chi_squared(100, 5, 50, .7)
-        5.4021875103989546e-06
+        5.402187510398...e-06
     """
     D1, D2 = chi_squared_cdf[d1], chi_squared_cdf[d2]
     l2 = RR(l2)
@@ -151,6 +151,77 @@ def drop(n, h, k, fail=0, rotations=False):
         return prob_drop
 
 
+def _log1mexp2(log_x):
+    """
+    Return ``log(1 - x)`` from ``log(x, 2)``.
+
+    This helper keeps amplification stable when ``x`` is so small that
+    ``1 - x`` rounds to one at ordinary working precision.
+
+    EXAMPLES::
+
+        >>> from estimator import prob
+        >>> from sage.all import floor, log
+        >>> floor(log(-1 / prob._log1mexp2(-10000), 2))
+        10000
+    """
+    if log_x >= 0:
+        return -oo
+
+    if log_x < -512:
+        return -(RR(2) ** log_x)
+
+    prec = max(53, 2 * ceil(abs(float(log_x))) + 16)
+    RR_ = RealField(prec)
+    x = RR_(2) ** RR_(log_x)
+    return log(1 - x)
+
+
+def amplify_from_log(target_success_probability, log_success_probability, majority=False):
+    """
+    Return the number of trials needed to amplify a log success probability.
+
+    ``log_success_probability`` is base two.  This is equivalent to
+    :func:`amplify` but avoids exponentiating tiny probabilities only to lose
+    them again when computing ``log(1 - p)``.
+
+    EXAMPLES::
+
+        >>> from estimator import prob
+        >>> from sage.all import floor, log, RR
+        >>> prob.amplify_from_log(0.99, -10000) < oo
+        True
+        >>> floor(log(prob.amplify_from_log(0.99, -10000), 2))
+        10002
+        >>> floor(log(prob.amplify(0.99, RR(2)**-10000), 2))
+        10002
+    """
+    if log_success_probability == -oo:
+        return oo
+
+    log_success_probability = RR(log_success_probability)
+    target_success_probability = RR(target_success_probability)
+
+    if log(target_success_probability, 2) < log_success_probability:
+        return ZZ(1)
+
+    try:
+        if majority:
+            # eps = p/2 and 4*eps^2 = p^2.
+            return ceil(
+                2 * log(2 - 2 * target_success_probability)
+                / _log1mexp2(2 * log_success_probability)
+            )
+        else:
+            # target_success_probability = 1 - (1-success_probability)^trials
+            return ceil(
+                log(1 - target_success_probability)
+                / _log1mexp2(log_success_probability)
+            )
+    except ValueError:
+        return oo
+
+
 def amplify(target_success_probability, success_probability, majority=False):
     """
     Return the number of trials needed to amplify current `success_probability` to
@@ -167,6 +238,9 @@ def amplify(target_success_probability, success_probability, majority=False):
         return ZZ(1)
     if success_probability == 0.0:
         return oo
+
+    if not majority:
+        return amplify_from_log(target_success_probability, log(success_probability, 2))
 
     prec = max(
         53,

--- a/estimator/sis_lattice.py
+++ b/estimator/sis_lattice.py
@@ -302,6 +302,7 @@ class SISLattice:
         self,
         params: SISParameters,
         zeta: int = None,
+        zeta_candidates=None,
         red_shape_model=red_shape_model_default,
         red_cost_model=red_cost_model_default,
         diagnostics=False,
@@ -313,6 +314,8 @@ class SISLattice:
 
         :param params: SIS parameters.
         :param zeta: Number of coefficients to set to 0 (ignore)
+        :param zeta_candidates: Candidate numbers of coefficients to set to 0 (ignore). If set,
+            only these candidates are evaluated and ``zeta`` must be ``None``.
         :param diagnostics: Include extra fields describing the infinity-norm probability model.
         :return: A cost dictionary
 
@@ -342,6 +345,11 @@ class SISLattice:
           ``diagnostics=True``.
         - ``vector_length``: Modeled short-vector length before coordinate probabilities, when
           ``diagnostics=True``.
+        - ``zeta_search``: Ignored-coordinate search mode, when ``diagnostics=True``.
+        - ``zeta_candidates``: Candidate ignored-coordinate counts, when ``diagnostics=True`` and
+          candidate search is used.
+        - ``rop_at_zeta_0``: Cost at ``zeta=0`` when ``diagnostics=True`` and ``0`` was evaluated
+          during candidate search.
 
         EXAMPLES::
 
@@ -420,6 +428,17 @@ class SISLattice:
             ... )
             >>> diag["linf_regime"], diag["gaussian_coords"], diag["idx_start"]
             ('dilithium_qary', 2066, 0)
+            >>> candidate_cost = SIS.lattice(
+            ...     schemes.Dilithium2_MSIS_WkUnf,
+            ...     red_cost_model=RC.ADPS16,
+            ...     red_shape_model="lgsa",
+            ...     zeta_candidates=[0],
+            ...     diagnostics=True,
+            ... )
+            >>> candidate_cost["beta"], candidate_cost["zeta_search"], candidate_cost["zeta_candidates"]
+            (423, 'candidates', (0,))
+            >>> candidate_cost["rop_at_zeta_0"] == candidate_cost["rop"]
+            True
 
         The success condition for euclidean norm bound is derived by determining the root hermite factor required for
         BKZ to produce the required output. For infinity norm bounds, the success conditions are derived using a
@@ -448,7 +467,38 @@ class SISLattice:
                 log_level=log_level + 1,
             )
 
-            if zeta is None:
+            if zeta is not None and zeta_candidates is not None:
+                raise ValueError("zeta and zeta_candidates cannot both be set.")
+
+            if zeta_candidates is not None:
+                zeta_candidates = tuple(dict.fromkeys(int(z) for z in zeta_candidates))
+                if not zeta_candidates:
+                    raise ValueError("zeta_candidates must not be empty.")
+                for zeta_candidate in zeta_candidates:
+                    if zeta_candidate < 0 or zeta_candidate > params.m:
+                        raise ValueError(
+                            f"zeta candidate {zeta_candidate} must satisfy 0 <= zeta <= m={params.m}."
+                        )
+                costs = {
+                    zeta_candidate: f(
+                        zeta=zeta_candidate,
+                        **kwds,
+                    )
+                    for zeta_candidate in zeta_candidates
+                }
+                cost = min(costs.values())
+                if diagnostics:
+                    cost.register_impermanent(
+                        zeta_search=False,
+                        zeta_candidates=False,
+                        rop_at_zeta_0=False,
+                    )
+                    cost["zeta_search"] = "candidates"
+                    cost["zeta_candidates"] = zeta_candidates
+                    if 0 in costs:
+                        cost["rop_at_zeta_0"] = costs[0]["rop"]
+
+            elif zeta is None:
                 with local_minimum(0, params.m, log_level=log_level) as it:
                     for zeta in it:
                         it.update(
@@ -459,8 +509,14 @@ class SISLattice:
                         )
                 # TODO: this should not be required
                 cost = min(it.y, f(0, **kwds))
+                if diagnostics:
+                    cost.register_impermanent(zeta_search=False)
+                    cost["zeta_search"] = "local_minimum"
             else:
                 cost = f(zeta=zeta)
+                if diagnostics:
+                    cost.register_impermanent(zeta_search=False)
+                    cost["zeta_search"] = "fixed"
 
         else:
             if simulator_normalize(red_shape_model) is not simulator_normalize(red_shape_model_default):

--- a/estimator/sis_lattice.py
+++ b/estimator/sis_lattice.py
@@ -309,8 +309,9 @@ class SISLattice:
         with local_minimum(40, beta_stop, precision=2, log_level=log_level + 1) as it:
             for beta in it:
                 it.update(f(beta))
-            for beta in it.neighborhood:
-                it.update(f(beta))
+            if it.y is not None:
+                for beta in it.neighborhood:
+                    it.update(f(beta))
             cost = it.y
 
         Logging.log("sis_infinity", log_level, f"H1: {cost!r}")

--- a/estimator/sis_lattice.py
+++ b/estimator/sis_lattice.py
@@ -8,15 +8,14 @@ See :ref:`SIS Lattice Attacks` for an introduction what is available.
 from functools import partial
 import warnings
 
-from sage.all import oo, sqrt, log, RR, floor, cached_function
+from sage.all import oo, sqrt, log, RR, floor, cached_function, erf
 from .reduction import beta as betaf
 from .reduction import cost as costf
 from .util import local_minimum
 from .cost import Cost
 from .sis_parameters import SISParameters
 from .simulator import normalize as simulator_normalize
-from .prob import gaussian_cdf
-from .prob import amplify as prob_amplify
+from .prob import amplify_from_log as prob_amplify_from_log
 from .io import Logging
 from .conf import red_cost_model as red_cost_model_default
 from .conf import red_shape_model as red_shape_model_default
@@ -44,6 +43,16 @@ class SISLattice:
         log_delta = log(params.length_bound, 2) ** 2 / (4 * params.n * RR(log(params.q, 2)))
         d = sqrt(params.n * log(params.q, 2) / log_delta)
         return d
+
+    @staticmethod
+    def _log_gaussian_linf_coordinate_probability(sigma, length_bound):
+        """
+        Return ``log2(Pr[|X| <= length_bound])`` for ``X`` sampled from ``N(0, sigma)``.
+
+        The probability is ``erf(length_bound/(sqrt(2)*sigma))``.  Using this
+        expression avoids the cancellation in ``1 - 2*Phi(-length_bound)``.
+        """
+        return RR(log(erf(length_bound / (sqrt(2) * sigma)), 2))
 
     @staticmethod
     @cached_function
@@ -160,7 +169,10 @@ class SISLattice:
             vector_length = rho * sqrt(r[0])
             # Find probability that all coordinates meet norm bound
             sigma = vector_length / sqrt(d_)
-            log_trial_prob = RR(d_ * log(1 - 2 * gaussian_cdf(0, sigma, -params.length_bound), 2))
+            log_gaussian_coordinate_prob = SISLattice._log_gaussian_linf_coordinate_probability(
+                sigma, params.length_bound
+            )
+            log_trial_prob = RR(d_ * log_gaussian_coordinate_prob)
             linf_regime = "matzov"
             idx_start = 0
             idx_end = d_ - 1
@@ -185,15 +197,17 @@ class SISLattice:
             gaussian_coords = max(idx_end - idx_start + 1, sieve_dim)
             sigma = vector_length / sqrt(gaussian_coords)
 
-            log_trial_prob = RR(
-                log(1 - 2 * gaussian_cdf(0, sigma, -params.length_bound), 2) * (gaussian_coords)
+            log_gaussian_coordinate_prob = SISLattice._log_gaussian_linf_coordinate_probability(
+                sigma, params.length_bound
             )
+            log_trial_prob = RR(log_gaussian_coordinate_prob * gaussian_coords)
             log_trial_prob += RR(log((2 * params.length_bound + 1) / params.q, 2) * (idx_start))
             linf_regime = "dilithium_qary"
 
-        probability = 2 ** min(
-            0, log_trial_prob + RR(log(N, 2))
+        log_success_probability = min(
+            RR(0), log_trial_prob + RR(log(N, 2))
         )  # expected number of solutions (max 1)
+        probability = 2 ** log_success_probability
         ret = Cost()
         ret["rop"] = cost_red
         ret["red"] = bkz_cost["rop"]
@@ -210,7 +224,9 @@ class SISLattice:
             ret["idx_start"] = idx_start
             ret["idx_end"] = idx_end
             ret["gaussian_coords"] = gaussian_coords
+            ret["log_gaussian_coordinate_prob"] = log_gaussian_coordinate_prob
             ret["log_trial_prob"] = log_trial_prob
+            ret["log_success_probability"] = log_success_probability
             ret["short_vectors"] = N
             ret["vector_length"] = vector_length
 
@@ -226,14 +242,16 @@ class SISLattice:
             idx_start=False,
             idx_end=False,
             gaussian_coords=False,
+            log_gaussian_coordinate_prob=False,
             log_trial_prob=False,
+            log_success_probability=False,
             short_vectors=False,
             vector_length=False,
         )
         # 4. Repeat whole experiment ~1/prob times
         if probability and not RR(probability).is_NaN():
             ret = ret.repeat(
-                prob_amplify(success_probability, probability),
+                prob_amplify_from_log(success_probability, log_success_probability),
             )
         else:
             return Cost(rop=oo)
@@ -374,8 +392,12 @@ class SISLattice:
         - ``idx_end``: Last non-unit-vector index in the Dilithium-style analysis, when
           ``diagnostics=True``.
         - ``gaussian_coords``: Number of Gaussian-modeled coordinates, when ``diagnostics=True``.
+        - ``log_gaussian_coordinate_prob``: Base-2 log probability that one Gaussian-modeled
+          coordinate satisfies the infinity-norm bound, when ``diagnostics=True``.
         - ``log_trial_prob``: Base-2 log probability for one generated short vector, when
           ``diagnostics=True``.
+        - ``log_success_probability``: Base-2 log success probability after accounting for the
+          generated short-vector count, capped above by zero, when ``diagnostics=True``.
         - ``short_vectors``: Number of generated short vectors used by the cost model, when
           ``diagnostics=True``.
         - ``vector_length``: Modeled short-vector length before coordinate probabilities, when

--- a/estimator/sis_lattice.py
+++ b/estimator/sis_lattice.py
@@ -263,6 +263,7 @@ class SISLattice:
         zeta: int,
         params: SISParameters,
         ignore_qary: bool = False,
+        baseline_beta=None,
         red_shape_model=red_shape_model_default,
         red_cost_model=red_cost_model_default,
         d=None,
@@ -274,21 +275,19 @@ class SISLattice:
         Ignored coordinates are set to 0 in the final SIS solution, so the dimension of the
         instance is treated as d-ζ.
         """
-        # step 0. establish baseline cost using worst case euclidean norm estimate
-        # length_bound =1 makes sense when norm=∞, but we take logs and divide
-        params_baseline = params.updated(
-            norm=2, length_bound=2 if params.length_bound == 1 else params.length_bound
-        )
-        baseline_cost = self(
-            params_baseline,
-            ignore_qary=ignore_qary,
-            red_shape_model=red_shape_model,
-            red_cost_model=red_cost_model,
-            log_level=log_level + 1,
-            **kwds,
-        )
-
-        Logging.log("sis_infinity", log_level, f"H0: {repr(baseline_cost)}")
+        if baseline_beta is None:
+            baseline_cost = self._cost_zeta_baseline(
+                params=params,
+                ignore_qary=ignore_qary,
+                red_shape_model=red_shape_model,
+                red_cost_model=red_cost_model,
+                log_level=log_level + 1,
+                **kwds,
+            )
+            baseline_beta = baseline_cost["beta"]
+            Logging.log("sis_infinity", log_level, f"H0: {repr(baseline_cost)}")
+        else:
+            Logging.log("sis_infinity", log_level, f"H0 β: {baseline_beta}")
 
         f = partial(
             SISLattice.cost_infinity,
@@ -302,9 +301,12 @@ class SISLattice:
         )
 
         # step 1. optimize β
-        with local_minimum(
-            40, baseline_cost["beta"] + 1, precision=2, log_level=log_level + 1
-        ) as it:
+        effective_d = (params.m if d is None else d) - zeta
+        beta_stop = min(baseline_beta, effective_d) + 1
+        if beta_stop <= 40:
+            return Cost(rop=oo)
+
+        with local_minimum(40, beta_stop, precision=2, log_level=log_level + 1) as it:
             for beta in it:
                 it.update(f(beta))
             for beta in it.neighborhood:
@@ -315,6 +317,31 @@ class SISLattice:
         if cost is None:
             return Cost(rop=oo)
         return cost
+
+    def _cost_zeta_baseline(
+        self,
+        params: SISParameters,
+        ignore_qary: bool = False,
+        red_shape_model=red_shape_model_default,
+        red_cost_model=red_cost_model_default,
+        log_level=5,
+        **kwds,
+    ):
+        """
+        Establish the Euclidean baseline used to bound infinity-norm beta searches.
+        """
+        # length_bound =1 makes sense when norm=∞, but we take logs and divide
+        params_baseline = params.updated(
+            norm=2, length_bound=2 if params.length_bound == 1 else params.length_bound
+        )
+        return self(
+            params_baseline,
+            ignore_qary=ignore_qary,
+            red_shape_model=red_shape_model,
+            red_cost_model=red_cost_model,
+            log_level=log_level,
+            **kwds,
+        )
 
     @staticmethod
     def cost_zeta_candidates(zeta_candidates, f, params, diagnostics=False, **kwds):
@@ -330,14 +357,18 @@ class SISLattice:
                     f"zeta candidate {zeta_candidate} must satisfy 0 <= zeta <= m={params.m}."
                 )
 
-        costs = {
-            zeta_candidate: f(
+        cost = None
+        rop_at_zeta_0 = None
+        for zeta_candidate in zeta_candidates:
+            candidate_cost = f(
                 zeta=zeta_candidate,
                 **kwds,
             )
-            for zeta_candidate in zeta_candidates
-        }
-        cost = min(costs.values())
+            if zeta_candidate == 0:
+                rop_at_zeta_0 = candidate_cost["rop"]
+            if cost is None or candidate_cost < cost:
+                cost = candidate_cost
+
         if diagnostics:
             cost.register_impermanent(
                 zeta_search=False,
@@ -346,8 +377,8 @@ class SISLattice:
             )
             cost["zeta_search"] = "candidates"
             cost["zeta_candidates"] = zeta_candidates
-            if 0 in costs:
-                cost["rop_at_zeta_0"] = costs[0]["rop"]
+            if rop_at_zeta_0 is not None:
+                cost["rop_at_zeta_0"] = rop_at_zeta_0
 
         return cost
 
@@ -515,17 +546,27 @@ class SISLattice:
             )
 
         if tag == "infinity":
+            if zeta is not None and zeta_candidates is not None:
+                raise ValueError("zeta and zeta_candidates cannot both be set.")
+
+            baseline_cost = self._cost_zeta_baseline(
+                params=params,
+                red_shape_model=red_shape_model,
+                red_cost_model=red_cost_model,
+                log_level=log_level + 1,
+                **kwds,
+            )
+            Logging.log("sis_infinity", log_level, f"H0: {repr(baseline_cost)}")
+
             f = partial(
                 self.cost_zeta,
                 params=params,
+                baseline_beta=baseline_cost["beta"],
                 red_shape_model=red_shape_model,
                 red_cost_model=red_cost_model,
                 diagnostics=diagnostics,
                 log_level=log_level + 1,
             )
-
-            if zeta is not None and zeta_candidates is not None:
-                raise ValueError("zeta and zeta_candidates cannot both be set.")
 
             if zeta_candidates is not None:
                 cost = self.cost_zeta_candidates(

--- a/estimator/sis_lattice.py
+++ b/estimator/sis_lattice.py
@@ -113,6 +113,7 @@ class SISLattice:
         zeta: int = 0,
         success_probability: float = 0.99,
         d=None,
+        diagnostics=False,
         red_shape_model=red_shape_model_default,
         red_cost_model=red_cost_model_default,
         log_level=None,
@@ -125,6 +126,7 @@ class SISLattice:
         :param beta: Block size used to produce short vectors for reduction
         :param zeta: Number of coefficients to set to 0 (ignore)
         :param success_probability: The success probability to target
+        :param diagnostics: Include extra fields describing the infinity-norm probability model.
         :param red_cost_model: How to cost lattice reduction
         :param red_shape_model: How to model the shape of a reduced basis.
 
@@ -151,12 +153,18 @@ class SISLattice:
         rho, cost_red, N, sieve_dim = red_cost_model.short_vectors(beta, d_)
         bkz_cost = costf(red_cost_model, beta, d_)
 
-        if RR(sqrt(d)) * params.length_bound <= params.q:  # Non-dilithium style analysis
+        sqrt_d_bound_over_q = RR(sqrt(d)) * params.length_bound / params.q
+
+        if sqrt_d_bound_over_q <= 1:  # Non-dilithium style analysis
             # Calculate expected vector length using approximation factor on the shortest vector from BKZ
             vector_length = rho * sqrt(r[0])
             # Find probability that all coordinates meet norm bound
             sigma = vector_length / sqrt(d_)
             log_trial_prob = RR(d_ * log(1 - 2 * gaussian_cdf(0, sigma, -params.length_bound), 2))
+            linf_regime = "matzov"
+            idx_start = 0
+            idx_end = d_ - 1
+            gaussian_coords = d_
 
         else:  # Dilithium style analysis
             # Find first non-q-vector in r
@@ -181,6 +189,7 @@ class SISLattice:
                 log(1 - 2 * gaussian_cdf(0, sigma, -params.length_bound), 2) * (gaussian_coords)
             )
             log_trial_prob += RR(log((2 * params.length_bound + 1) / params.q, 2) * (idx_start))
+            linf_regime = "dilithium_qary"
 
         probability = 2 ** min(
             0, log_trial_prob + RR(log(N, 2))
@@ -195,6 +204,16 @@ class SISLattice:
         ret["d"] = d_
         ret["prob"] = probability
 
+        if diagnostics:
+            ret["linf_regime"] = linf_regime
+            ret["sqrt_d_bound_over_q"] = sqrt_d_bound_over_q
+            ret["idx_start"] = idx_start
+            ret["idx_end"] = idx_end
+            ret["gaussian_coords"] = gaussian_coords
+            ret["log_trial_prob"] = log_trial_prob
+            ret["short_vectors"] = N
+            ret["vector_length"] = vector_length
+
         ret.register_impermanent(
             rop=True,
             red=True,
@@ -202,6 +221,14 @@ class SISLattice:
             eta=False,
             zeta=False,
             prob=False,
+            linf_regime=False,
+            sqrt_d_bound_over_q=False,
+            idx_start=False,
+            idx_end=False,
+            gaussian_coords=False,
+            log_trial_prob=False,
+            short_vectors=False,
+            vector_length=False,
         )
         # 4. Repeat whole experiment ~1/prob times
         if probability and not RR(probability).is_NaN():
@@ -277,6 +304,7 @@ class SISLattice:
         zeta: int = None,
         red_shape_model=red_shape_model_default,
         red_cost_model=red_cost_model_default,
+        diagnostics=False,
         log_level=1,
         **kwds,
     ):
@@ -285,6 +313,7 @@ class SISLattice:
 
         :param params: SIS parameters.
         :param zeta: Number of coefficients to set to 0 (ignore)
+        :param diagnostics: Include extra fields describing the infinity-norm probability model.
         :return: A cost dictionary
 
         The returned cost dictionary has the following entries:
@@ -299,6 +328,20 @@ class SISLattice:
         - ``prob``: Probability of success in guessing.
         - ``repeat``: How often to repeat the attack.
         - ``d``: Lattice dimension.
+        - ``linf_regime``: Infinity-norm probability model, when ``diagnostics=True``.
+        - ``sqrt_d_bound_over_q``: Branch ratio ``sqrt(d) * length_bound / q``, when
+          ``diagnostics=True``.
+        - ``idx_start``: First non-q-vector index in the Dilithium-style analysis, when
+          ``diagnostics=True``.
+        - ``idx_end``: Last non-unit-vector index in the Dilithium-style analysis, when
+          ``diagnostics=True``.
+        - ``gaussian_coords``: Number of Gaussian-modeled coordinates, when ``diagnostics=True``.
+        - ``log_trial_prob``: Base-2 log probability for one generated short vector, when
+          ``diagnostics=True``.
+        - ``short_vectors``: Number of generated short vectors used by the cost model, when
+          ``diagnostics=True``.
+        - ``vector_length``: Modeled short-vector length before coordinate probabilities, when
+          ``diagnostics=True``.
 
         EXAMPLES::
 
@@ -326,6 +369,58 @@ class SISLattice:
             >>> SIS.lattice(params.updated(norm=oo, length_bound=1), red_shape_model="cn11")
             rop: ≈2^246.2, red: ≈2^245.1, sieve: ≈2^245.2, β: 764, η: 751, ζ: 0, d: 2486, prob: 1, ↻: 1, tag: infinity
 
+            >>> SIS.lattice(
+            ...     schemes.Dilithium2_MSIS_WkUnf,
+            ...     red_cost_model=RC.ADPS16,
+            ...     red_shape_model="lgsa",
+            ...     zeta=0,
+            ... )["beta"]
+            423
+            >>> SIS.lattice(
+            ...     schemes.Dilithium3_MSIS_WkUnf,
+            ...     red_cost_model=RC.ADPS16,
+            ...     red_shape_model="lgsa",
+            ...     zeta=0,
+            ... )["beta"]
+            638
+            >>> SIS.lattice(
+            ...     schemes.Dilithium5_MSIS_WkUnf,
+            ...     red_cost_model=RC.ADPS16,
+            ...     red_shape_model="lgsa",
+            ...     zeta=0,
+            ... )["beta"]
+            909
+            >>> SIS.lattice(
+            ...     schemes.Dilithium2_MSIS_StrUnf,
+            ...     red_cost_model=RC.ADPS16,
+            ...     red_shape_model="lgsa",
+            ...     zeta=0,
+            ... )["beta"]
+            417
+            >>> SIS.lattice(
+            ...     schemes.Dilithium3_MSIS_StrUnf,
+            ...     red_cost_model=RC.ADPS16,
+            ...     red_shape_model="lgsa",
+            ...     zeta=0,
+            ... )["beta"]
+            602
+            >>> SIS.lattice(
+            ...     schemes.Dilithium5_MSIS_StrUnf,
+            ...     red_cost_model=RC.ADPS16,
+            ...     red_shape_model="lgsa",
+            ...     zeta=0,
+            ... )["beta"]
+            868
+            >>> diag = SIS.lattice(
+            ...     schemes.Dilithium2_MSIS_WkUnf,
+            ...     red_cost_model=RC.ADPS16,
+            ...     red_shape_model="lgsa",
+            ...     zeta=0,
+            ...     diagnostics=True,
+            ... )
+            >>> diag["linf_regime"], diag["gaussian_coords"], diag["idx_start"]
+            ('dilithium_qary', 2066, 0)
+
         The success condition for euclidean norm bound is derived by determining the root hermite factor required for
         BKZ to produce the required output. For infinity norm bounds, the success conditions are derived using a
         probabilistic analysis. Vectors are assumed to be short as in [MATZOV22]_ P.18, or [Dilithium21]_ P.35.
@@ -349,6 +444,7 @@ class SISLattice:
                 params=params,
                 red_shape_model=red_shape_model,
                 red_cost_model=red_cost_model,
+                diagnostics=diagnostics,
                 log_level=log_level + 1,
             )
 

--- a/estimator/sis_lattice.py
+++ b/estimator/sis_lattice.py
@@ -298,6 +298,41 @@ class SISLattice:
             return Cost(rop=oo)
         return cost
 
+    @staticmethod
+    def cost_zeta_candidates(zeta_candidates, f, params, diagnostics=False, **kwds):
+        """
+        Evaluate an explicit list of ignored-coordinate candidates and return the cheapest cost.
+        """
+        zeta_candidates = tuple(dict.fromkeys(int(z) for z in zeta_candidates))
+        if not zeta_candidates:
+            raise ValueError("zeta_candidates must not be empty.")
+        for zeta_candidate in zeta_candidates:
+            if zeta_candidate < 0 or zeta_candidate > params.m:
+                raise ValueError(
+                    f"zeta candidate {zeta_candidate} must satisfy 0 <= zeta <= m={params.m}."
+                )
+
+        costs = {
+            zeta_candidate: f(
+                zeta=zeta_candidate,
+                **kwds,
+            )
+            for zeta_candidate in zeta_candidates
+        }
+        cost = min(costs.values())
+        if diagnostics:
+            cost.register_impermanent(
+                zeta_search=False,
+                zeta_candidates=False,
+                rop_at_zeta_0=False,
+            )
+            cost["zeta_search"] = "candidates"
+            cost["zeta_candidates"] = zeta_candidates
+            if 0 in costs:
+                cost["rop_at_zeta_0"] = costs[0]["rop"]
+
+        return cost
+
     def __call__(
         self,
         params: SISParameters,
@@ -471,32 +506,13 @@ class SISLattice:
                 raise ValueError("zeta and zeta_candidates cannot both be set.")
 
             if zeta_candidates is not None:
-                zeta_candidates = tuple(dict.fromkeys(int(z) for z in zeta_candidates))
-                if not zeta_candidates:
-                    raise ValueError("zeta_candidates must not be empty.")
-                for zeta_candidate in zeta_candidates:
-                    if zeta_candidate < 0 or zeta_candidate > params.m:
-                        raise ValueError(
-                            f"zeta candidate {zeta_candidate} must satisfy 0 <= zeta <= m={params.m}."
-                        )
-                costs = {
-                    zeta_candidate: f(
-                        zeta=zeta_candidate,
-                        **kwds,
-                    )
-                    for zeta_candidate in zeta_candidates
-                }
-                cost = min(costs.values())
-                if diagnostics:
-                    cost.register_impermanent(
-                        zeta_search=False,
-                        zeta_candidates=False,
-                        rop_at_zeta_0=False,
-                    )
-                    cost["zeta_search"] = "candidates"
-                    cost["zeta_candidates"] = zeta_candidates
-                    if 0 in costs:
-                        cost["rop_at_zeta_0"] = costs[0]["rop"]
+                cost = self.cost_zeta_candidates(
+                    zeta_candidates,
+                    f,
+                    params,
+                    diagnostics=diagnostics,
+                    **kwds,
+                )
 
             elif zeta is None:
                 with local_minimum(0, params.m, log_level=log_level) as it:


### PR DESCRIPTION
## Summary

- add `zeta_candidates` for infinity-norm SIS estimates so callers can evaluate an explicit ignored-coordinate candidate set
- preserve the existing default `zeta=None` local optimizer and fixed integer `zeta` behavior
- expose the ignored-coordinate search mode, evaluated candidates, and `zeta=0` cost in diagnostics
- compute the Euclidean beta baseline once per top-level infinity-norm estimate and reuse it across zeta evaluations
- cap each fixed-zeta beta search at the effective dimension `d - zeta` to avoid probing impossible block sizes
- stream candidate evaluation instead of materializing all candidate costs
- split the candidate-search logic out of `SISLattice.__call__` to keep the estimator entry point readable and within the existing flake8 complexity budget
- document candidate-set search for reproducible parameter sweeps

This PR is stacked on #215 and should be reviewed after it. #215 contains the generic infinity-norm diagnostics and log-probability amplification hardening; this PR adds the explicit zeta-search control surface and avoids redundant zeta-search work on top.

## Validation

- `python3 -m flake8 estimator/`
- `sage -python -m pytest -o addopts='' --doctest-modules --doctest-glob='*.rst' estimator/prob.py estimator/sis_lattice.py docs/algorithms/sis-lattice.rst -q`
- `git diff --check`

Posted by Codex assistant (model: GPT-5) on behalf of the user (Quang Dao) with approval.
