### PR TITLE
sis: fix triviality check for Euclidean norm

### DIFF
--- a/estimator/sis_lattice.py
+++ b/estimator/sis_lattice.py
@@ -75,8 +75,8 @@ class SISLattice:
 
         """
         # Check for triviality
-        if params.length_bound >= (params.q - 1) / 2:
-            raise ValueError("SIS trivially easy. Please set norm bound < (q-1)/2.")
+        if params.length_bound >= params.q:
+            raise ValueError("SIS trivially easy. Please set norm bound < q.")
 
         if d is None:
             d = min(floor(SISLattice._opt_sis_d(params)), params.m)


### PR DESCRIPTION
The condition should check $B \ge q$, not $B \ge (q-1)/2$, where $B$ is the norm bound. The latter is only correct for infinity norm. For Euclidean norm, a unit vector $(q, 0, \dots, 0)$ with norm $q$ is already a valid trivial SIS solution.

Fixes #162
